### PR TITLE
XML Push Response Mapper

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,7 +16,6 @@ return PhpCsFixer\Config::create()
             'method_argument_space' => true,
             'no_empty_statement' => true,
             'no_leading_import_slash' => true,
-            'no_leading_namespace_whitespace' => true,
             'no_multiline_whitespace_around_double_arrow' => true,
             'no_multiline_whitespace_before_semicolons' => true,
             'no_singleline_whitespace_before_semicolons' => true,

--- a/composer.json
+++ b/composer.json
@@ -2,16 +2,22 @@
 	"name" : "heidelpay/php-api",
 	"description" : "Client library for heidelpay payments.",
 	"license" : "Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.",
-	"authors" : [{
+	"authors" : [
+		{
 			"name" : "Jens Richter"
-		}, {
+		},
+		{
 			"name" : "Ronja Wann"
+		},
+		{
+			"name": "Stephano Vogel"
 		}
 	],
 	"require" : {
 		"php" : ">=5.6.0",
 		"lib-curl" : "*",
-		"lib-openssl" : "*"
+		"lib-openssl" : "*",
+		"ext-simplexml": "*"
 	},
 	"require-dev" : {
 		"phpunit/phpunit" : "~5.7",

--- a/lib/AbstractMethod.php
+++ b/lib/AbstractMethod.php
@@ -1,9 +1,25 @@
 <?php
+
 namespace Heidelpay\PhpApi;
+
+use Heidelpay\PhpApi\ParameterGroups\AccountParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\AddressParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\BasketParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\ConfigParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\ContactParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\CriterionParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\FrontendParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\IdentificationParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\NameParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\PaymentParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\PresentationParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\RequestParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\SecurityParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\TransactionParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\UserParameterGroup;
 
 /**
  * Abstract request/response class
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -18,15 +34,13 @@ namespace Heidelpay\PhpApi;
  */
 abstract class AbstractMethod
 {
-    /* Post Parameter Group */
-    
     /**
      * AccountParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\AccountParameterGroup
      */
     protected $account = null;
-    
+
     /**
      * AddressParameterGroup
      *
@@ -47,56 +61,56 @@ abstract class AbstractMethod
      * @var \Heidelpay\PhpApi\ParameterGroups\ConfigParameterGroup
      */
     protected $config = null;
-    
+
     /**
      * ContactParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\ContactParameterGroup
      */
     protected $contact = null;
-    
+
     /**
      * CriterionParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\CriterionParameterGroup
      */
     protected $criterion = null;
-    
+
     /**
      * FrontendParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\FrontendParameterGroup
      */
     protected $frontend = null;
-    
+
     /**
      * IdentificationParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\IdentificationParameterGroup
      */
     protected $identification = null;
-    
+
     /**
      * NameParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\NameParameterGroup
      */
     protected $name = null;
-    
+
     /**
      * PaymentParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\PaymentParameterGroup
      */
     protected $payment = null;
-    
+
     /**
      * Post
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\PostParameterGroup
      */
     protected $post = null;
-    
+
     /**
      * PresentationParameterGroup
      *
@@ -104,49 +118,49 @@ abstract class AbstractMethod
      */
     protected $presentation = null;
 
-    
+
     /**
      * RequestParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\RequestParameterGroup
      */
     protected $request = null;
-    
+
     /**
      * SecurityParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\SecurityParameterGroup
      */
     protected $security = null;
-    
+
     /**
      * ShopParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\ShopParameterGroup
      */
     protected $shop = null;
-    
+
     /**
      * ShopmoduleParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\ShopmoduleParameterGroup
      */
     protected $shopmodule = null;
-    
+
     /**
      * TransactionParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\TransactionParameterGroup
      */
     protected $transaction = null;
-    
+
     /**
      * UserParameterGroup
      *
      * @var \Heidelpay\PhpApi\ParameterGroups\UserParameterGroup
      */
     protected $user = null;
-    
+
     /**
      * Account getter
      *
@@ -155,7 +169,7 @@ abstract class AbstractMethod
     public function getAccount()
     {
         if ($this->account === null) {
-            return $this->account = new \Heidelpay\PhpApi\ParameterGroups\AccountParameterGroup;
+            return $this->account = new AccountParameterGroup();
         }
         return $this->account;
     }
@@ -168,7 +182,7 @@ abstract class AbstractMethod
     public function getAddress()
     {
         if ($this->address === null) {
-            return $this->address = new \Heidelpay\PhpApi\ParameterGroups\AddressParameterGroup;
+            return $this->address = new AddressParameterGroup();
         }
         return $this->address;
     }
@@ -181,7 +195,7 @@ abstract class AbstractMethod
     public function getBasket()
     {
         if ($this->basket === null) {
-            return $this->basket = new \Heidelpay\PhpApi\ParameterGroups\BasketParameterGroup;
+            return $this->basket = new BasketParameterGroup();
         }
         return $this->basket;
     }
@@ -194,11 +208,11 @@ abstract class AbstractMethod
     public function getConfig()
     {
         if ($this->config === null) {
-            return $this->config = new \Heidelpay\PhpApi\ParameterGroups\ConfigParameterGroup();
+            return $this->config = new ConfigParameterGroup();
         }
         return $this->config;
     }
-    
+
     /**
      * Contact getter
      *
@@ -207,11 +221,11 @@ abstract class AbstractMethod
     public function getContact()
     {
         if ($this->contact === null) {
-            return $this->contact = new \Heidelpay\PhpApi\ParameterGroups\ContactParameterGroup;
+            return $this->contact = new ContactParameterGroup();
         }
         return $this->contact;
     }
-    
+
     /**
      * Criterion getter
      *
@@ -220,7 +234,7 @@ abstract class AbstractMethod
     public function getCriterion()
     {
         if ($this->criterion === null) {
-            return $this->criterion = new \Heidelpay\PhpApi\ParameterGroups\CriterionParameterGroup;
+            return $this->criterion = new CriterionParameterGroup();
         }
         return $this->criterion;
     }
@@ -233,7 +247,7 @@ abstract class AbstractMethod
     public function getFrontend()
     {
         if ($this->frontend === null) {
-            return $this->frontend = new \Heidelpay\PhpApi\ParameterGroups\FrontendParameterGroup;
+            return $this->frontend = new FrontendParameterGroup();
         }
         return $this->frontend;
     }
@@ -246,7 +260,7 @@ abstract class AbstractMethod
     public function getIdentification()
     {
         if ($this->identification === null) {
-            return $this->identification = new \Heidelpay\PhpApi\ParameterGroups\IdentificationParameterGroup;
+            return $this->identification = new IdentificationParameterGroup();
         }
         return $this->identification;
     }
@@ -259,7 +273,7 @@ abstract class AbstractMethod
     public function getName()
     {
         if ($this->name === null) {
-            return $this->name = new \Heidelpay\PhpApi\ParameterGroups\NameParameterGroup;
+            return $this->name = new NameParameterGroup();
         }
         return $this->name;
     }
@@ -272,7 +286,7 @@ abstract class AbstractMethod
     public function getPayment()
     {
         if ($this->payment === null) {
-            return $this->payment = new \Heidelpay\PhpApi\ParameterGroups\PaymentParameterGroup;
+            return $this->payment = new PaymentParameterGroup();
         }
         return $this->payment;
     }
@@ -285,7 +299,7 @@ abstract class AbstractMethod
     public function getPresentation()
     {
         if ($this->presentation === null) {
-            return $this->presentation = new \Heidelpay\PhpApi\ParameterGroups\PresentationParameterGroup;
+            return $this->presentation = new PresentationParameterGroup();
         }
         return $this->presentation;
     }
@@ -298,7 +312,7 @@ abstract class AbstractMethod
     public function getRequest()
     {
         if ($this->request === null) {
-            return $this->request = new \Heidelpay\PhpApi\ParameterGroups\RequestParameterGroup;
+            return $this->request = new RequestParameterGroup();
         }
         return $this->request;
     }
@@ -311,7 +325,7 @@ abstract class AbstractMethod
     public function getSecurity()
     {
         if ($this->security === null) {
-            return $this->security = new \Heidelpay\PhpApi\ParameterGroups\SecurityParameterGroup;
+            return $this->security = new SecurityParameterGroup();
         }
         return $this->security;
     }
@@ -324,7 +338,7 @@ abstract class AbstractMethod
     public function getTransaction()
     {
         if ($this->transaction === null) {
-            return $this->transaction = new \Heidelpay\PhpApi\ParameterGroups\TransactionParameterGroup;
+            return $this->transaction = new TransactionParameterGroup();
         }
         return $this->transaction;
     }
@@ -337,7 +351,7 @@ abstract class AbstractMethod
     public function getUser()
     {
         if ($this->user === null) {
-            return $this->user = new \Heidelpay\PhpApi\ParameterGroups\UserParameterGroup;
+            return $this->user = new UserParameterGroup();
         }
         return $this->user;
     }

--- a/lib/Adapter/CurlAdapter.php
+++ b/lib/Adapter/CurlAdapter.php
@@ -23,7 +23,6 @@ use Heidelpay\PhpApi\Response;
  * @subpackage PhpApi
  * @category PhpApi
  */
- 
 class CurlAdapter
 {
     /**
@@ -34,19 +33,20 @@ class CurlAdapter
      *
      * @return array result of the transaction and a instance of the response object
      */
-    public function sendPost($uri=null, $post=null)
+    public function sendPost($uri = null, $post = null)
     {
         $request = $result = null;
         $response = $error = $info = array();
 
         if (!extension_loaded('curl')) {
-            $result = array( 'PROCESSING_RESULT' => 'NOK',
+            $result = array(
+                'PROCESSING_RESULT' => 'NOK',
                 'PROCESSING_RETURN' => 'Connection error php-curl not installed',
                 'PROCESSING_RETURN_CODE' => 'CON.ERR.CUR'
             );
             return array($result, new Response($result));
         }
-        
+
 
         $request = curl_init();
         curl_setopt($request, CURLOPT_URL, $uri);
@@ -54,32 +54,36 @@ class CurlAdapter
         curl_setopt($request, CURLOPT_FAILONERROR, true);
         curl_setopt($request, CURLOPT_TIMEOUT, 60);
         curl_setopt($request, CURLOPT_CONNECTTIMEOUT, 60);
-            
+
         if (is_array($post)) {
             curl_setopt($request, CURLOPT_POST, true);
             curl_setopt($request, CURLOPT_POSTFIELDS, http_build_query($post));
         }
-            
+
         curl_setopt($request, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($request, CURLOPT_SSL_VERIFYPEER, 1);
         curl_setopt($request, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($request, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
         curl_setopt($request, CURLOPT_USERAGENT, "PhpApi");
-            
+
         $response = curl_exec($request);
         $error = curl_error($request);
         $info = curl_getinfo($request, CURLINFO_HTTP_CODE);
-            
-        curl_close($request);
-            
-        if (isset($error) and !empty($error)) {
-            $errorCode = (is_array($info) && array_key_exists('CURLINFO_HTTP_CODE', $info)) ? $info['CURLINFO_HTTP_CODE'] : 'DEF';
-            $result = array( 'PROCESSING_RESULT' => 'NOK',
-                    'PROCESSING_RETURN' => 'Connection error http status '.$error,
-                    'PROCESSING_RETURN_CODE' => 'CON.ERR.'.$errorCode
-                );
-        }
 
+        curl_close($request);
+
+        if (isset($error) and !empty($error)) {
+            $errorCode =
+                (is_array($info) && array_key_exists('CURLINFO_HTTP_CODE', $info))
+                    ? $info['CURLINFO_HTTP_CODE']
+                    : 'DEF';
+
+            $result = array(
+                'PROCESSING_RESULT' => 'NOK',
+                'PROCESSING_RETURN' => 'Connection error http status ' . $error,
+                'PROCESSING_RETURN_CODE' => 'CON.ERR.' . $errorCode
+            );
+        }
 
         if (empty($error) && is_string($response)) {
             parse_str($response, $result);

--- a/lib/Exceptions/HashVerificationException.php
+++ b/lib/Exceptions/HashVerificationException.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Heidelpay\PhpApi\Exceptions;
+
+use Exception;
 
 /**
  *  This class is used for indicating a hash verification issue
@@ -15,8 +18,6 @@ namespace Heidelpay\PhpApi\Exceptions;
  * @subpackage PhpApi
  * @category PhpApi
  */
-use Exception;
-
 class HashVerificationException extends Exception
 {
 }

--- a/lib/Exceptions/PaymentFormUrlException.php
+++ b/lib/Exceptions/PaymentFormUrlException.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Heidelpay\PhpApi\Exceptions;
+
+use Exception;
 
 /**
  *  This class is used for indicating a hash verification issue
@@ -15,8 +18,6 @@ namespace Heidelpay\PhpApi\Exceptions;
  * @subpackage PhpApi
  * @category PhpApi
  */
-use Exception;
-
 class PaymentFormUrlException extends Exception
 {
 }

--- a/lib/Exceptions/UndefinedPropertyException.php
+++ b/lib/Exceptions/UndefinedPropertyException.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Heidelpay\PhpApi\Exceptions;
+
+use Exception;
 
 /**
  *  This class is used for indicating a use of an undefined property
@@ -15,8 +18,6 @@ namespace Heidelpay\PhpApi\Exceptions;
  * @subpackage PhpApi
  * @category PhpApi
  */
-use Exception;
-
 class UndefinedPropertyException extends Exception
 {
 }

--- a/lib/Exceptions/UndefinedTransactionModeException.php
+++ b/lib/Exceptions/UndefinedTransactionModeException.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Heidelpay\PhpApi\Exceptions;
+
+use Exception;
 
 /**
  *  This class is used for indicating a use of an undefined transaction mode
@@ -15,8 +18,6 @@ namespace Heidelpay\PhpApi\Exceptions;
  * @subpackage PhpApi
  * @category PhpApi
  */
-use Exception;
-
 class UndefinedTransactionModeException extends Exception
 {
 }

--- a/lib/Exceptions/UndefinedXmlResponseException.php
+++ b/lib/Exceptions/UndefinedXmlResponseException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Heidelpay\PhpApi\Exceptions;
+
+use Exception;
+
+/**
+ * UndefinedXmlResponseException
+ *
+ * Indicates that a XML response is not present, but asked to be parsed.
+ *
+ * @license    Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright  Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link       https://dev.heidelpay.de/php-api
+ *
+ * @author     Stephano Vogel
+ *
+ * @package    heidelpay
+ * @subpackage php-api
+ * @category   php-api
+ */
+class UndefinedXmlResponseException extends Exception
+{
+}

--- a/lib/Exceptions/XmlResponseParserException.php
+++ b/lib/Exceptions/XmlResponseParserException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Heidelpay\PhpApi\Exceptions;
+
+use Exception;
+
+/**
+ * UndefinedXmlResponseException
+ *
+ * Indicates that there was an error during XML parsing.
+ *
+ * @license    Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright  Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link       https://dev.heidelpay.de/php-api
+ *
+ * @author     Stephano Vogel
+ *
+ * @package    heidelpay
+ * @subpackage php-api
+ * @category   php-api
+ */
+class XmlResponseParserException extends Exception
+{
+}

--- a/lib/ParameterGroups/AbstractParameterGroup.php
+++ b/lib/ParameterGroups/AbstractParameterGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 use Heidelpay\PhpApi\Exceptions\UndefinedPropertyException;
@@ -7,16 +8,16 @@ use Heidelpay\PhpApi\Request;
 /**
  *  The AbstractParameterGroup provides functions for every parameter group which extends this class
  *
- * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @license    Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ * @copyright  Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *
- * @link  https://dev.heidelpay.de/PhpApi
+ * @link       https://dev.heidelpay.de/PhpApi
  *
- * @author  Jens Richter
+ * @author     Jens Richter
  *
- * @package  Heidelpay
+ * @package    Heidelpay
  * @subpackage PhpApi
- * @category PhpApi
+ * @category   PhpApi
  */
 abstract class AbstractParameterGroup
 {
@@ -29,7 +30,7 @@ abstract class AbstractParameterGroup
     {
         return get_called_class();
     }
-    
+
     /**
      * Magic setter
      *
@@ -44,8 +45,11 @@ abstract class AbstractParameterGroup
     {
         $key = strtolower($key);
 
-        if (! property_exists($this, $key) && $this instanceof Request) {
-            throw new UndefinedPropertyException('Property does not exist: '.$key.' in '. $this->getClassName(), 500);
+        if (!property_exists($this, $key) && $this instanceof Request) {
+            throw new UndefinedPropertyException(
+                'Property does not exist: ' . $key . ' in ' . $this->getClassName(),
+                500
+            );
         }
 
         $this->$key = $value;

--- a/lib/ParameterGroups/AbstractParameterGroup.php
+++ b/lib/ParameterGroups/AbstractParameterGroup.php
@@ -2,6 +2,7 @@
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 use Heidelpay\PhpApi\Exceptions\UndefinedPropertyException;
+use Heidelpay\PhpApi\Request;
 
 /**
  *  The AbstractParameterGroup provides functions for every parameter group which extends this class
@@ -42,11 +43,12 @@ abstract class AbstractParameterGroup
     public function set($key, $value)
     {
         $key = strtolower($key);
-        if (property_exists($this, $key)) {
-            $this->$key = $value;
-            return $this;
+
+        if (! property_exists($this, $key) && $this instanceof Request) {
+            throw new UndefinedPropertyException('Property does not exist: '.$key.' in '. $this->getClassName(), 500);
         }
 
-        throw new UndefinedPropertyException('Property does not exist: '.$key.' in '. $this->getClassName(), 500);
+        $this->$key = $value;
+        return $this;
     }
 }

--- a/lib/ParameterGroups/AccountParameterGroup.php
+++ b/lib/ParameterGroups/AccountParameterGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
@@ -42,7 +43,7 @@ class AccountParameterGroup extends AbstractParameterGroup
      * @var string brand of the given account
      */
     public $brand = null;
-    
+
     /**
      * Bic - Business identifier code used for non sepa direct debit
      *
@@ -56,28 +57,28 @@ class AccountParameterGroup extends AbstractParameterGroup
      * @var string country of the given account
      */
     public $country = null;
-    
+
     /**
      * Expiry month used for credit and debit cards
      *
      * @var string expiry month of the given account
      */
     public $expiry_month = null;
-    
+
     /**
      * Expiry year used for credit and debit cards
      *
      * @var string expiry year of the given account
      */
     public $expiry_year = null;
-    
-   /**
-    * Owner of the given account data
-    *
+
+    /**
+     * Owner of the given account data
+     *
      * @var string holder of the given account
      */
     public $holder = null;
-    
+
     /**
      * International bank account number
      *
@@ -91,15 +92,15 @@ class AccountParameterGroup extends AbstractParameterGroup
      * @var string sepa mandate id from the payment response
      */
     public $identification = null;
-    
+
     /**
      * Account number can be used for non sepa direct debit transactions
      *
      * @var string number of the given account
      */
     public $number = null;
-    
-    
+
+
     /**
      * @var string verification of the given account
      */
@@ -126,7 +127,7 @@ class AccountParameterGroup extends AbstractParameterGroup
     {
         return $this->bankname;
     }
-    
+
     /**
      *  AccountBrand getter
      *
@@ -156,7 +157,7 @@ class AccountParameterGroup extends AbstractParameterGroup
     {
         return $this->country;
     }
-    
+
     /**
      * AccountExpiryMonth getter
      *
@@ -166,7 +167,7 @@ class AccountParameterGroup extends AbstractParameterGroup
     {
         return $this->expiry_month;
     }
-    
+
     /**
      * AccountExpiryYear getter
      *
@@ -176,7 +177,7 @@ class AccountParameterGroup extends AbstractParameterGroup
     {
         return $this->expiry_year;
     }
-    
+
     /**
      * AccountHolder getter
      *
@@ -186,7 +187,7 @@ class AccountParameterGroup extends AbstractParameterGroup
     {
         return $this->holder;
     }
-    
+
     /**
      * AccountIban getter
      *
@@ -206,7 +207,7 @@ class AccountParameterGroup extends AbstractParameterGroup
     {
         return $this->identification;
     }
-    
+
     /**
      * AccountNumber getter
      *

--- a/lib/ParameterGroups/AddressParameterGroup.php
+++ b/lib/ParameterGroups/AddressParameterGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
@@ -20,29 +21,31 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class AddressParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * @var string city of the customers billingaddress (mandatory)
      */
     public $city = null;
-    
+
     /**
      * @var string county of the customers billingaddress in ISO 3166-1 2 digits (mandatory)
      */
     public $country = null;
+
     /**
      * @var string state of the customers billingaddress in ISO 3166-2 (optinal)
      */
     public $state = null;
+
     /**
      * @var string street of the customers billingaddress (mandatory)
      */
     public $street = null;
+
     /**
      * @var string zip code of the customers billingaddress (mandatory)
      */
     public $zip = null;
-    
+
     /**
      * AddressCity getter
      *
@@ -52,8 +55,8 @@ class AddressParameterGroup extends AbstractParameterGroup
     {
         return $this->city;
     }
-     
-     /**
+
+    /**
      * AddressCountry getter
      *
      * @return string country
@@ -62,7 +65,7 @@ class AddressParameterGroup extends AbstractParameterGroup
     {
         return $this->country;
     }
-    
+
     /**
      * AddressState getter
      *
@@ -72,7 +75,7 @@ class AddressParameterGroup extends AbstractParameterGroup
     {
         return $this->state;
     }
-    
+
     /**
      * AddressStreet getter
      *
@@ -82,7 +85,7 @@ class AddressParameterGroup extends AbstractParameterGroup
     {
         return $this->street;
     }
-    
+
     /**
      * AddressZip getter
      *

--- a/lib/ParameterGroups/BasketParameterGroup.php
+++ b/lib/ParameterGroups/BasketParameterGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
@@ -21,7 +22,6 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class BasketParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * Basket id
      *

--- a/lib/ParameterGroups/ConfigParameterGroup.php
+++ b/lib/ParameterGroups/ConfigParameterGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
@@ -17,14 +18,13 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class ConfigParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * Supported bank countries for this payment method
      *
      * @var string bankcountry
      */
     public $bankcountry = null;
-    
+
     /**
      *  Supported brands countries for this payment method
      *
@@ -38,7 +38,7 @@ class ConfigParameterGroup extends AbstractParameterGroup
      * @var string optin text for santander invoice
      */
     public $optin_text = null;
-        
+
     /**
      * Config bankcountry getter
      *
@@ -48,7 +48,7 @@ class ConfigParameterGroup extends AbstractParameterGroup
     {
         return json_decode($this->bankcountry, true);
     }
-    
+
     /**
      * Config brands getter
      *

--- a/lib/ParameterGroups/ConnectorParameterGroup.php
+++ b/lib/ParameterGroups/ConnectorParameterGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
@@ -90,7 +91,6 @@ class ConnectorParameterGroup extends AbstractParameterGroup
      * @return string account bank
      *
      * @deprecated please use IBan and Bic instead
-
      */
     public function getAccountBank()
     {

--- a/lib/ParameterGroups/ContactParameterGroup.php
+++ b/lib/ParameterGroups/ContactParameterGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
@@ -17,7 +18,6 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class ContactParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * Contact EMail
      *
@@ -26,7 +26,7 @@ class ContactParameterGroup extends AbstractParameterGroup
      * @var string email address of the customer (mandatory)
      */
     public $email = null;
-    
+
     /**
      * Customer Ip
      *
@@ -56,7 +56,7 @@ class ContactParameterGroup extends AbstractParameterGroup
      * @var string phone of the customer (optional)
      */
     public $phone = null;
-        
+
     /**
      * ContactEmail getter
      *
@@ -66,7 +66,7 @@ class ContactParameterGroup extends AbstractParameterGroup
     {
         return $this->email;
     }
-    
+
     /**
      * ContactIp getter
      *

--- a/lib/ParameterGroups/CriterionParameterGroup.php
+++ b/lib/ParameterGroups/CriterionParameterGroup.php
@@ -22,35 +22,34 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class CriterionParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * Currently used payment methode
      *
-     * @var sting payment methode
+     * @var string payment methode
      */
     public $payment_method = null;
-    
+
     /**
      * hash to verify the response
      *
      * @var string hash to verify the response
      */
     public $secret = null;
-    
+
     /**
      * Sdk name
      *
      * @var string sdk name
      */
     public $sdk_name = "Heidelpay\PhpApi";
-    
+
     /**
      * Sdk version
      *
      * @var string version
      */
     public $sdk_version = "17.3.20";
-    
+
     /**
      * CriterionPaymentMethod getter
      *
@@ -60,7 +59,7 @@ class CriterionParameterGroup extends AbstractParameterGroup
     {
         return $this->payment_method;
     }
-    
+
     /**
      * CriterionSecret setter
      *
@@ -74,10 +73,10 @@ class CriterionParameterGroup extends AbstractParameterGroup
      */
     public function setSecret($value, $secret)
     {
-        $this->secret = hash('sha512', $value.$secret);
+        $this->secret = hash('sha512', $value . $secret);
         return $this;
     }
-    
+
     /**
      * CriterionSecret getter
      *
@@ -87,7 +86,7 @@ class CriterionParameterGroup extends AbstractParameterGroup
     {
         return $this->secret;
     }
-    
+
     /**
      * Magic setter without property exception
      *

--- a/lib/ParameterGroups/FrontendParameterGroup.php
+++ b/lib/ParameterGroups/FrontendParameterGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
@@ -17,43 +18,42 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class FrontendParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      *  FrontendCssPath
      *
      * @var string url for a custom css to style the hpf. Only required for hpf
      */
     public $css_path = null;
-    
-    
+
+
     /**
      * FrontendEnabled
      *
      * @var boolean enable for async from submit or disable for sync  (mandatory)
      */
     public $enabled = 'TRUE';
-    
+
     /**
      * FrontendLanguage
      *
      * @var string language code ISO 639-1 (mandatory)
      */
     public $language = null;
-    
+
     /**
      * FrontendMode
      *
      * @var string always set to withelabel on ngw (mandatory)
      */
     public $mode = "WHITELABEL";
-    
+
     /**
      * FrontendPaymentFrameOrigin
      *
      * @var string origin of your website (like "http://dev.heidelpay.de/"). Only required for hpf
      */
     public $payment_frame_origin = null;
-    
+
     /**
      * FrontendPaymentFrameUrl
      *
@@ -71,21 +71,21 @@ class FrontendParameterGroup extends AbstractParameterGroup
      * @var boolean weather redirect is active or not
      */
     public $prevent_async_redirect = null;
-    
+
     /**
      * FrontendRedirectUrl
      *
      * @var string url for whitelabel payment from
      */
     public $redirect_url = null;
-    
+
     /**
      * FrontendResponseUrl
      *
      * @var string url of your system for async payment response (mandatory)
      */
     public $response_url = null;
-    
+
     /**
      * FrontendEnabled getter
      *
@@ -95,7 +95,7 @@ class FrontendParameterGroup extends AbstractParameterGroup
     {
         return $this->enabled;
     }
-    
+
     /**
      * FrontendLanguage getter
      *
@@ -105,7 +105,7 @@ class FrontendParameterGroup extends AbstractParameterGroup
     {
         return $this->language;
     }
-    
+
     /**
      * FrontendRedirectUrl getter
      *
@@ -115,7 +115,7 @@ class FrontendParameterGroup extends AbstractParameterGroup
     {
         return $this->redirect_url;
     }
-    
+
     /**
      * FrontendResponseUrl getter
      *
@@ -125,7 +125,7 @@ class FrontendParameterGroup extends AbstractParameterGroup
     {
         return $this->response_url;
     }
-    
+
     /**
      * FrontendPaymentFrameOrigin getter
      *
@@ -135,7 +135,7 @@ class FrontendParameterGroup extends AbstractParameterGroup
     {
         return $this->payment_frame_origin;
     }
-    
+
     /**
      * FrontendPaymentFrameUrl getter
      *
@@ -145,7 +145,7 @@ class FrontendParameterGroup extends AbstractParameterGroup
     {
         return $this->payment_frame_url;
     }
-    
+
     /**
      * FrontendCssPath getter
      *
@@ -155,7 +155,7 @@ class FrontendParameterGroup extends AbstractParameterGroup
     {
         return $this->css_path;
     }
-    
+
     /**
      * FrontendReventAsyncRedirect
      *

--- a/lib/ParameterGroups/IdentificationParameterGroup.php
+++ b/lib/ParameterGroups/IdentificationParameterGroup.php
@@ -1,10 +1,9 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
  * This class provides every api parameter used to identify a transaction.
- *
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -19,14 +18,13 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class IdentificationParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * Creditor id
      *
      * @var string creditor id
      */
     public $creditor_id = null;
-    
+
     /**
      * IdentificationShopperId
      *
@@ -36,7 +34,7 @@ class IdentificationParameterGroup extends AbstractParameterGroup
      * @var string customer identification number (optional)
      */
     public $shopperid = null;
-    
+
     /**
      * IdentificationShortId
      *
@@ -46,7 +44,7 @@ class IdentificationParameterGroup extends AbstractParameterGroup
      * @var string heidelpay short identifier
      */
     public $shortid = null;
-    
+
     /**
      * IdentificatonTransactionId
      *
@@ -56,7 +54,7 @@ class IdentificationParameterGroup extends AbstractParameterGroup
      * @var string order identification number (optional)
      */
     public $transactionid = null;
-    
+
     /**
      * IdentificationrefernceId
      *
@@ -68,7 +66,7 @@ class IdentificationParameterGroup extends AbstractParameterGroup
      * @var string payment reference Id, for example the uniqe Id of the invoice autorisation
      */
     public $referenceid = null;
-    
+
     /**
      * IdentificationUniqeId
      *
@@ -78,7 +76,7 @@ class IdentificationParameterGroup extends AbstractParameterGroup
      * @var string payment long identifier also know as uniqeId
      */
     public $uniqueid = null;
-    
+
     /**
      * IdentificationCreditorId getter
      *
@@ -88,7 +86,7 @@ class IdentificationParameterGroup extends AbstractParameterGroup
     {
         return $this->creditor_id;
     }
-    
+
     /**
      * IdentificationShopperid getter
      *
@@ -98,7 +96,7 @@ class IdentificationParameterGroup extends AbstractParameterGroup
     {
         return $this->shopperid;
     }
-    
+
     /**
      * IdentificationShortid getter
      *
@@ -118,7 +116,7 @@ class IdentificationParameterGroup extends AbstractParameterGroup
     {
         return $this->transactionid;
     }
-    
+
     /**
      * IdentificationReferenceId getter
      *
@@ -128,7 +126,7 @@ class IdentificationParameterGroup extends AbstractParameterGroup
     {
         return $this->referenceid;
     }
-    
+
     /**
      * IdentificationUniqueId getter
      *

--- a/lib/ParameterGroups/NameParameterGroup.php
+++ b/lib/ParameterGroups/NameParameterGroup.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
  * This class provides every api parameter of the "name" namespace
  *
  * It will be used for parameters like given name, but also for salutation etc.
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -20,7 +20,6 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class NameParameterGroup extends AbstractParameterGroup
 {
-
     /**
      * NameBirthdate
      *
@@ -38,7 +37,7 @@ class NameParameterGroup extends AbstractParameterGroup
      * @var string company name (optional)
      */
     public $company = null;
-    
+
     /**
      * NameGiven
      *
@@ -47,7 +46,7 @@ class NameParameterGroup extends AbstractParameterGroup
      * @var string given name of the customer (mandatory)
      */
     public $given = null;
-    
+
     /**
      * NameFamily
      *
@@ -96,7 +95,7 @@ class NameParameterGroup extends AbstractParameterGroup
     {
         return $this->company;
     }
-    
+
     /**
      * NameGiven getter
      *
@@ -106,7 +105,7 @@ class NameParameterGroup extends AbstractParameterGroup
     {
         return $this->given;
     }
-    
+
     /**
      * NameFamily getter
      *

--- a/lib/ParameterGroups/PaymentParameterGroup.php
+++ b/lib/ParameterGroups/PaymentParameterGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
@@ -20,7 +21,6 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class PaymentParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * PaymentCode
      *
@@ -34,7 +34,7 @@ class PaymentParameterGroup extends AbstractParameterGroup
      * @var string code (mandatory)
      */
     public $code = null;
-    
+
     /**
      * PamyentCode getter
      *

--- a/lib/ParameterGroups/PresentationParameterGroup.php
+++ b/lib/ParameterGroups/PresentationParameterGroup.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
  * This class provides the api parameter for amount and currency.
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -18,7 +18,6 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class PresentationParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * PresentationAmount
      *
@@ -27,7 +26,7 @@ class PresentationParameterGroup extends AbstractParameterGroup
      * @var float amount (mandatory)
      */
     public $amount = null;
-    
+
     /**
      * PresentationCurrency
      *
@@ -59,7 +58,7 @@ class PresentationParameterGroup extends AbstractParameterGroup
     {
         return $this->amount;
     }
-    
+
     /**
      * PresentationCurrency getter
      *

--- a/lib/ParameterGroups/ProcessingParameterGroup.php
+++ b/lib/ParameterGroups/ProcessingParameterGroup.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
  * This class provides the api parameter for the payment response like reason code.
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -18,77 +18,76 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class ProcessingParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * ProcessingCode
      *
      * @var string code
      */
     public $code = null;
-    
+
     /**
      * ProcessingConfirmationStatus
      *
-     * @var sting confirmation status
+     * @var string confirmation status
      */
     public $confirmation_status = null;
-    
+
     /**
      * ProcessingRecoverable
      *
      * @var string recoverable
      */
     public $recoverable = null;
-    
+
     /**
      * ProcessingResult
      *
      * @var string payment transaction result
      */
     public $result = null;
-    
+
     /**
      * ProcessingReasonCode
      *
      * @var string reson_code transaction result
      */
     public $reason_code = null;
-    
+
     /**
      * ProcessingReason
      *
      * @var string reson transaction result
      */
     public $reason = null;
-    
+
     /**
      * ProcessingReturn
      *
      * @var string status message for the shop owner
      */
     public $return = null;
-    
+
     /**
      * ProcessingReturnCode
      *
      * @var string status code for the shop owner
      */
     public $return_code = null;
-    
+
     public $timestamp = null;
-    
+
     /**
      * @var string status message of the transaction
      */
-    public $status= null;
-    
+    public $status = null;
+
     /**
      * ProcessingStatusCode
      *
      * @var string status code of the transaction (100.100.100)
      */
     public $status_code = null;
-    
+
     /**
      * Magic setter without property exception
      *
@@ -98,7 +97,7 @@ class ProcessingParameterGroup extends AbstractParameterGroup
      * @param string $key
      * @param string $value
      *
-     * @return \Heidelpay\PhpApi\ParameterGroups\CriterionParameterGroup
+     * @return \Heidelpay\PhpApi\ParameterGroups\ProcessingParameterGroup
      */
     public function set($key, $value)
     {
@@ -106,7 +105,7 @@ class ProcessingParameterGroup extends AbstractParameterGroup
         $this->$key = $value;
         return $this;
     }
-    
+
     /**
      * ProcessingResult getter
      *
@@ -116,7 +115,7 @@ class ProcessingParameterGroup extends AbstractParameterGroup
     {
         return $this->result;
     }
-    
+
     /**
      * ProcessingRetrun message getter
      *
@@ -126,7 +125,7 @@ class ProcessingParameterGroup extends AbstractParameterGroup
     {
         return $this->return;
     }
-    
+
     /**
      * ProcessingRetrun code getter
      *
@@ -136,7 +135,7 @@ class ProcessingParameterGroup extends AbstractParameterGroup
     {
         return $this->return_code;
     }
-    
+
     /**
      * ProcessingStatusCode getter
      *

--- a/lib/ParameterGroups/RequestParameterGroup.php
+++ b/lib/ParameterGroups/RequestParameterGroup.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
  * This class provides sets the request version
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -18,14 +18,13 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class RequestParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * RequestVersion
      *
      * @var string version (mandatory)
      */
     public $version = '1.0';
-    
+
     /**
      * RequestVersion getter
      *

--- a/lib/ParameterGroups/SecurityParameterGroup.php
+++ b/lib/ParameterGroups/SecurityParameterGroup.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
  * This class provides authentification parameters
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -18,7 +18,6 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class SecurityParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * SecuritySender
      *
@@ -27,7 +26,7 @@ class SecurityParameterGroup extends AbstractParameterGroup
      * @var string sender (mandatory)
      */
     public $sender = null;
-    
+
     /**
      * SecuritySender getter
      *

--- a/lib/ParameterGroups/TransactionParameterGroup.php
+++ b/lib/ParameterGroups/TransactionParameterGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
@@ -17,9 +18,8 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  * @subpackage PhpApi
  * @category PhpApi
  */
- class TransactionParameterGroup extends AbstractParameterGroup
- {
-    
+class TransactionParameterGroup extends AbstractParameterGroup
+{
     /**
      * TransactionChannel
      *
@@ -29,7 +29,7 @@ namespace Heidelpay\PhpApi\ParameterGroups;
      * @var string channel (mandatory)
      */
     public $channel = null;
-    
+
     /**
      * TransactionMode
      *
@@ -40,7 +40,7 @@ namespace Heidelpay\PhpApi\ParameterGroups;
      * @var string mode (mandatory)
      */
     public $mode = "CONNECTOR_TEST";
-    
+
     /**
      * TransactionChannel getter
      *
@@ -50,7 +50,7 @@ namespace Heidelpay\PhpApi\ParameterGroups;
     {
         return $this->channel;
     }
-    
+
     /**
      * TransactionMode getter
      *
@@ -60,4 +60,4 @@ namespace Heidelpay\PhpApi\ParameterGroups;
     {
         return $this->mode;
     }
- }
+}

--- a/lib/ParameterGroups/UserParameterGroup.php
+++ b/lib/ParameterGroups/UserParameterGroup.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Heidelpay\PhpApi\ParameterGroups;
 
 /**
  * This classe provides authentification parameter for the payment api
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -18,7 +18,6 @@ namespace Heidelpay\PhpApi\ParameterGroups;
  */
 class UserParameterGroup extends AbstractParameterGroup
 {
-    
     /**
      * UserLogin
      *
@@ -26,7 +25,7 @@ class UserParameterGroup extends AbstractParameterGroup
      * @var string login (mandatory)
      */
     public $login = null;
-    
+
     /**
      * UserPwd
      *
@@ -35,7 +34,7 @@ class UserParameterGroup extends AbstractParameterGroup
      * @var string pwd (mandatory)
      */
     public $pwd = null;
-    
+
     /**
      * user login getter
      *
@@ -45,7 +44,7 @@ class UserParameterGroup extends AbstractParameterGroup
     {
         return $this->login;
     }
-    
+
     /**
      *  user password getter
      *

--- a/lib/PaymentMethods/AbstractPaymentMethod.php
+++ b/lib/PaymentMethods/AbstractPaymentMethod.php
@@ -8,7 +8,6 @@ use Heidelpay\PhpApi\TransactionTypes\RefundTransactionType;
 /**
  * This classe is the abstract payment method
  *
- *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *
@@ -34,7 +33,7 @@ abstract class AbstractPaymentMethod
      * @var string payment code
      */
     protected $_paymentCode = null;
-    
+
     /**
      * Payment brand name for this payment method
      *

--- a/lib/PaymentMethods/BasicPaymentMethodTrait.php
+++ b/lib/PaymentMethods/BasicPaymentMethodTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\PaymentMethods;
 
 use Heidelpay\PhpApi\Exceptions\UndefinedTransactionModeException;
@@ -23,7 +24,6 @@ use Heidelpay\PhpApi\Request as HeidelpayRequest;
  */
 trait BasicPaymentMethodTrait
 {
-
     /**
      * Payment Url of the live payment server
      *
@@ -31,7 +31,7 @@ trait BasicPaymentMethodTrait
      *
      * @var string url for heidelpay api connection real or live system
      */
-    protected $_liveUrl       = 'https://heidelpay.hpcgw.net/ngw/post';
+    protected $_liveUrl = 'https://heidelpay.hpcgw.net/ngw/post';
 
     /**
      * Payment Url of the sandbox payment server
@@ -40,7 +40,7 @@ trait BasicPaymentMethodTrait
      *
      * @var string url for heidelpay api connection sandbox system
      */
-    protected $_sandboxUrl     = 'https://test-heidelpay.hpcgw.net/ngw/post';
+    protected $_sandboxUrl = 'https://test-heidelpay.hpcgw.net/ngw/post';
 
     /**
      * HTTP Adapter for payment connection
@@ -118,7 +118,7 @@ trait BasicPaymentMethodTrait
             return $this->_request = new HeidelpayRequest();
         }
 
-        return  $this->_request;
+        return $this->_request;
     }
 
     /**
@@ -149,7 +149,7 @@ trait BasicPaymentMethodTrait
      */
     public function getAdapter()
     {
-        return  $this->_adapter;
+        return $this->_adapter;
     }
 
     /**

--- a/lib/PaymentMethods/CreditCardPaymentMethod.php
+++ b/lib/PaymentMethods/CreditCardPaymentMethod.php
@@ -71,12 +71,9 @@ class CreditCardPaymentMethod
      * Because of payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string $CssPath - css url to style the Heidelpay payment frame
-     * @param null|mixed $PaymentFrameOrigin
-     * @param mixed $PreventAsyncRedirect
-     * @param null|mixed $CssPath
+     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param mixed      $PreventAsyncRedirect - prevention of redirecting the customer
+     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */
@@ -97,12 +94,9 @@ class CreditCardPaymentMethod
      * Because of payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string $CssPath - css url to style the Heidelpay payment frame
-     * @param null|mixed $PaymentFrameOrigin
-     * @param mixed $PreventAsyncRedirect
-     * @param null|mixed $CssPath
+     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param mixed      $PreventAsyncRedirect prevention of redirecting the customer
+     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */
@@ -124,12 +118,9 @@ class CreditCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string $CssPath - css url to style the Heidelpay payment frame
-     * @param null|mixed $PaymentFrameOrigin
-     * @param mixed $PreventAsyncRedirect
-     * @param null|mixed $CssPath
+     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param mixed      $PreventAsyncRedirect prevention of redirecting the customer
+     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */

--- a/lib/PaymentMethods/CreditCardPaymentMethod.php
+++ b/lib/PaymentMethods/CreditCardPaymentMethod.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\PaymentMethods;
 
 use Heidelpay\PhpApi\TransactionTypes\RegistrationTransactionType;
@@ -15,7 +16,6 @@ use Heidelpay\PhpApi\TransactionTypes\RebillTransactionType;
  * Credit Card Payment Class
  *
  * This class will be used for every credit card transaction
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -71,11 +71,11 @@ class CreditCardPaymentMethod
      * Because of payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string CSSPath - css url to style the Heidelpay payment frame
+     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
+     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
+     * @param string $CssPath - css url to style the Heidelpay payment frame
      * @param null|mixed $PaymentFrameOrigin
-     * @param mixed      $PreventAsyncRedirect
+     * @param mixed $PreventAsyncRedirect
      * @param null|mixed $CssPath
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
@@ -86,10 +86,10 @@ class CreditCardPaymentMethod
         $this->getRequest()->getFrontend()->set('payment_frame_origin', $PaymentFrameOrigin);
         $this->getRequest()->getFrontend()->set('prevent_async_redirect', $PreventAsyncRedirect);
         $this->getRequest()->getFrontend()->set('css_path', $CssPath);
-            
+
         return $this->authorizeParent();
     }
-    
+
     /**
      * Payment type debit
      *
@@ -97,11 +97,11 @@ class CreditCardPaymentMethod
      * Because of payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string CSSPath - css url to style the Heidelpay payment frame
+     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
+     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
+     * @param string $CssPath - css url to style the Heidelpay payment frame
      * @param null|mixed $PaymentFrameOrigin
-     * @param mixed      $PreventAsyncRedirect
+     * @param mixed $PreventAsyncRedirect
      * @param null|mixed $CssPath
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
@@ -111,10 +111,10 @@ class CreditCardPaymentMethod
         $this->getRequest()->getFrontend()->set('payment_frame_origin', $PaymentFrameOrigin);
         $this->getRequest()->getFrontend()->set('prevent_async_redirect', $PreventAsyncRedirect);
         $this->getRequest()->getFrontend()->set('css_path', $CssPath);
-    
+
         return $this->debitParent();
     }
-    
+
     /**
      * Payment type registration
      *
@@ -124,11 +124,11 @@ class CreditCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string CSSPath - css url to style the Heidelpay payment frame
+     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
+     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
+     * @param string $CssPath - css url to style the Heidelpay payment frame
      * @param null|mixed $PaymentFrameOrigin
-     * @param mixed      $PreventAsyncRedirect
+     * @param mixed $PreventAsyncRedirect
      * @param null|mixed $CssPath
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
@@ -138,7 +138,7 @@ class CreditCardPaymentMethod
         $this->getRequest()->getFrontend()->set('payment_frame_origin', $PaymentFrameOrigin);
         $this->getRequest()->getFrontend()->set('prevent_async_redirect', $PreventAsyncRedirect);
         $this->getRequest()->getFrontend()->set('css_path', $CssPath);
-    
+
         return $this->registrationParent();
     }
 }

--- a/lib/PaymentMethods/CreditCardPaymentMethod.php
+++ b/lib/PaymentMethods/CreditCardPaymentMethod.php
@@ -17,16 +17,16 @@ use Heidelpay\PhpApi\TransactionTypes\RebillTransactionType;
  *
  * This class will be used for every credit card transaction
  *
- * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @license    Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ * @copyright  Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *
- * @link  https://dev.heidelpay.de/PhpApi
+ * @link       https://dev.heidelpay.de/PhpApi
  *
- * @author  Jens Richter
+ * @author     Jens Richter
  *
- * @package  Heidelpay
+ * @package    Heidelpay
  * @subpackage PhpApi
- * @category PhpApi
+ * @category   PhpApi
  */
 class CreditCardPaymentMethod
 {
@@ -71,9 +71,9 @@ class CreditCardPaymentMethod
      * Because of payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param null|mixed $PaymentFrameOrigin   uri of your application like https://dev.heidelpay.de
      * @param mixed      $PreventAsyncRedirect - prevention of redirecting the customer
-     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
+     * @param null|mixed $CssPath              css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */
@@ -94,9 +94,9 @@ class CreditCardPaymentMethod
      * Because of payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param null|mixed $PaymentFrameOrigin   uri of your application like https://dev.heidelpay.de
      * @param mixed      $PreventAsyncRedirect prevention of redirecting the customer
-     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
+     * @param null|mixed $CssPath              css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */
@@ -118,9 +118,9 @@ class CreditCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param null|mixed $PaymentFrameOrigin   uri of your application like https://dev.heidelpay.de
      * @param mixed      $PreventAsyncRedirect prevention of redirecting the customer
-     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
+     * @param null|mixed $CssPath              css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */

--- a/lib/PaymentMethods/DebitCardPaymentMethod.php
+++ b/lib/PaymentMethods/DebitCardPaymentMethod.php
@@ -17,7 +17,6 @@ use Heidelpay\PhpApi\TransactionTypes\RebillTransactionType;
  *
  * This class will be used for every debit card transaction
  *
- *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *
@@ -73,11 +72,11 @@ class DebitCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string CSSPath - css url to style the Heidelpay payment frame
+     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
+     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
+     * @param string $CssPath - css url to style the Heidelpay payment frame
      * @param null|mixed $PaymentFrameOrigin
-     * @param mixed      $PreventAsyncRedirect
+     * @param mixed $PreventAsyncRedirect
      * @param null|mixed $CssPath
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
@@ -103,11 +102,11 @@ class DebitCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string CSSPath - css url to style the Heidelpay payment frame
+     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
+     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
+     * @param string $CssPath - css url to style the Heidelpay payment frame
      * @param null|mixed $PaymentFrameOrigin
-     * @param mixed      $PreventAsyncRedirect
+     * @param mixed $PreventAsyncRedirect
      * @param null|mixed $CssPath
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
@@ -134,11 +133,11 @@ class DebitCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string CSSPath - css url to style the Heidelpay payment frame
+     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
+     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
+     * @param string $CssPath - css url to style the Heidelpay payment frame
      * @param null|mixed $PaymentFrameOrigin
-     * @param mixed      $PreventAsyncRedirect
+     * @param mixed $PreventAsyncRedirect
      * @param null|mixed $CssPath
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean

--- a/lib/PaymentMethods/DebitCardPaymentMethod.php
+++ b/lib/PaymentMethods/DebitCardPaymentMethod.php
@@ -17,16 +17,16 @@ use Heidelpay\PhpApi\TransactionTypes\RebillTransactionType;
  *
  * This class will be used for every debit card transaction
  *
- * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @license    Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ * @copyright  Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *
- * @link  https://dev.heidelpay.de/PhpApi
+ * @link       https://dev.heidelpay.de/PhpApi
  *
- * @author  Jens Richter
+ * @author     Jens Richter
  *
- * @package  Heidelpay
+ * @package    Heidelpay
  * @subpackage PhpApi
- * @category PhpApi
+ * @category   PhpApi
  */
 class DebitCardPaymentMethod
 {
@@ -72,9 +72,9 @@ class DebitCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param null|mixed $PaymentFrameOrigin   uri of your application like https://dev.heidelpay.de
      * @param mixed      $PreventAsyncRedirect prevention of redirecting the customer
-     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
+     * @param null|mixed $CssPath              css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */
@@ -99,9 +99,9 @@ class DebitCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param null|mixed $PaymentFrameOrigin   uri of your application like https://dev.heidelpay.de
      * @param mixed      $PreventAsyncRedirect prevention of redirecting the customer
-     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
+     * @param null|mixed $CssPath              css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */
@@ -127,9 +127,9 @@ class DebitCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param null|mixed $PaymentFrameOrigin   uri of your application like https://dev.heidelpay.de
      * @param mixed      $PreventAsyncRedirect prevention of redirecting the customer
-     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
+     * @param null|mixed $CssPath              css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */

--- a/lib/PaymentMethods/DebitCardPaymentMethod.php
+++ b/lib/PaymentMethods/DebitCardPaymentMethod.php
@@ -72,12 +72,9 @@ class DebitCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string $CssPath - css url to style the Heidelpay payment frame
-     * @param null|mixed $PaymentFrameOrigin
-     * @param mixed $PreventAsyncRedirect
-     * @param null|mixed $CssPath
+     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param mixed      $PreventAsyncRedirect prevention of redirecting the customer
+     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */
@@ -102,12 +99,9 @@ class DebitCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string $CssPath - css url to style the Heidelpay payment frame
-     * @param null|mixed $PaymentFrameOrigin
-     * @param mixed $PreventAsyncRedirect
-     * @param null|mixed $CssPath
+     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param mixed      $PreventAsyncRedirect prevention of redirecting the customer
+     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */
@@ -133,12 +127,9 @@ class DebitCardPaymentMethod
      * Because of the payment card industry restrictions (Aka pci3), you have
      * to use a payment frame solution to handle the customers credit card information.
      *
-     * @param string $PaymentFrameOrigin - uri of your application like https://dev.heidelpay.de
-     * @param boolean $PreventAsyncRedirect - this will tell the payment weather it should redirect the customer or not
-     * @param string $CssPath - css url to style the Heidelpay payment frame
-     * @param null|mixed $PaymentFrameOrigin
-     * @param mixed $PreventAsyncRedirect
-     * @param null|mixed $CssPath
+     * @param null|mixed $PaymentFrameOrigin uri of your application like https://dev.heidelpay.de
+     * @param mixed      $PreventAsyncRedirect prevention of redirecting the customer
+     * @param null|mixed $CssPath css url to style the Heidelpay payment frame
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod|boolean
      */

--- a/lib/PaymentMethods/DirectDebitB2CSecuredPaymentMethod.php
+++ b/lib/PaymentMethods/DirectDebitB2CSecuredPaymentMethod.php
@@ -42,7 +42,7 @@ class DirectDebitB2CSecuredPaymentMethod
     use CaptureTransactionType;
     use RebillTransactionType;
     use FinalizeTransactionType;
-    
+
     /**
      * Payment code for this payment method
      *

--- a/lib/PaymentMethods/DirectDebitPaymentMethod.php
+++ b/lib/PaymentMethods/DirectDebitPaymentMethod.php
@@ -40,7 +40,7 @@ class DirectDebitPaymentMethod
     use ReversalTransactionType;
     use CaptureTransactionType;
     use RebillTransactionType;
-    
+
     /**
      * Payment code for this payment method
      *

--- a/lib/PaymentMethods/EPSPaymentMethod.php
+++ b/lib/PaymentMethods/EPSPaymentMethod.php
@@ -20,21 +20,20 @@ namespace Heidelpay\PhpApi\PaymentMethods;
  */
 class EPSPaymentMethod extends AbstractPaymentMethod
 {
-    
     /**
      * Payment code for this payment method
      *
      * @var string payment code
      */
     protected $_paymentCode = 'OT';
-    
+
     /**
      * Weather this Payment method can authorise transactions or not
      *
      * @var boolean canAuthorise
      */
     protected $_canAuthorise = true;
-    
+
     /**
      * Weather this Payment method can refund transactions or not
      *

--- a/lib/PaymentMethods/GiropayPaymentMethod.php
+++ b/lib/PaymentMethods/GiropayPaymentMethod.php
@@ -20,21 +20,20 @@ namespace Heidelpay\PhpApi\PaymentMethods;
  */
 class GiropayPaymentMethod extends AbstractPaymentMethod
 {
-    
     /**
      * Payment code for this payment method
      *
      * @var string payment code
      */
     protected $_paymentCode = 'OT';
-    
+
     /**
      * Weather this Payment method can authorise transactions or not
      *
      * @var boolean canAuthorise
      */
     protected $_canAuthorise = true;
-    
+
     /**
      * Weather this Payment method can refund transactions or not
      *

--- a/lib/PaymentMethods/IDealPaymentMethod.php
+++ b/lib/PaymentMethods/IDealPaymentMethod.php
@@ -20,21 +20,20 @@ namespace Heidelpay\PhpApi\PaymentMethods;
  */
 class IDealPaymentMethod extends AbstractPaymentMethod
 {
-    
     /**
      * Payment code for this payment method
      *
      * @var string payment code
      */
     protected $_paymentCode = 'OT';
-    
+
     /**
      * Weather this Payment method can authorise transactions or not
      *
      * @var boolean canAuthorise
      */
     protected $_canAuthorise = true;
-    
+
     /**
      * Payment brand name for this payment method
      *

--- a/lib/PaymentMethods/InvoicePaymentMethod.php
+++ b/lib/PaymentMethods/InvoicePaymentMethod.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\PaymentMethods;
 
 use Heidelpay\PhpApi\TransactionTypes\AuthorizeTransactionType;
@@ -9,7 +10,6 @@ use Heidelpay\PhpApi\TransactionTypes\RefundTransactionType;
  * Invoice Payment Class
  *
  * This payment method is the classic unsecured invoice.
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.

--- a/lib/PaymentMethods/PayPalPaymentMethod.php
+++ b/lib/PaymentMethods/PayPalPaymentMethod.php
@@ -15,7 +15,6 @@ use Heidelpay\PhpApi\TransactionTypes\RebillTransactionType;
 /**
  * PayPal Payment Class
  *
- *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *
@@ -39,7 +38,7 @@ class PayPalPaymentMethod
     use ReversalTransactionType;
     use CaptureTransactionType;
     use RebillTransactionType;
-    
+
     /**
      * Payment code for this payment method
      *

--- a/lib/PaymentMethods/PostFinanceCardPaymentMethod.php
+++ b/lib/PaymentMethods/PostFinanceCardPaymentMethod.php
@@ -20,21 +20,20 @@ namespace Heidelpay\PhpApi\PaymentMethods;
  */
 class PostFinanceCardPaymentMethod extends AbstractPaymentMethod
 {
-    
     /**
      * Payment code for this payment method
      *
      * @var string payment code
      */
     protected $_paymentCode = 'OT';
-    
+
     /**
      * Weather this Payment method can authorise transactions or not
      *
      * @var boolean canAuthorise
      */
     protected $_canAuthorise = true;
-    
+
     /**
      * Weather this Payment method can refund transactions or not
      *

--- a/lib/PaymentMethods/PostFinanceEFinancePaymentMethod.php
+++ b/lib/PaymentMethods/PostFinanceEFinancePaymentMethod.php
@@ -20,21 +20,20 @@ namespace Heidelpay\PhpApi\PaymentMethods;
  */
 class PostFinanceEFinancePaymentMethod extends AbstractPaymentMethod
 {
-    
     /**
      * Payment code for this payment method
      *
      * @var string payment code
      */
     protected $_paymentCode = 'OT';
-    
+
     /**
      * Weather this Payment method can authorise transactions or not
      *
      * @var boolean canAuthorise
      */
     protected $_canAuthorise = true;
-    
+
     /**
      * Weather this Payment method can refund transactions or not
      *

--- a/lib/PaymentMethods/PrepaymentPaymentMethod.php
+++ b/lib/PaymentMethods/PrepaymentPaymentMethod.php
@@ -9,7 +9,6 @@ use Heidelpay\PhpApi\TransactionTypes\RefundTransactionType;
 /**
  * Prepayment Payment Class
  *
- *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *

--- a/lib/PaymentMethods/Przelewy24PaymentMethod.php
+++ b/lib/PaymentMethods/Przelewy24PaymentMethod.php
@@ -20,21 +20,20 @@ namespace Heidelpay\PhpApi\PaymentMethods;
  */
 class Przelewy24PaymentMethod extends AbstractPaymentMethod
 {
-    
     /**
      * Payment code for this payment method
      *
      * @var string payment code
      */
     protected $_paymentCode = 'OT';
-    
+
     /**
      * Weather this Payment method can authorise transactions or not
      *
      * @var boolean canAuthorise
      */
     protected $_canAuthorise = true;
-    
+
     /**
      * Weather this Payment method can refund transactions or not
      *

--- a/lib/PaymentMethods/SofortPaymentMethod.php
+++ b/lib/PaymentMethods/SofortPaymentMethod.php
@@ -26,13 +26,14 @@ class SofortPaymentMethod
     use BasicPaymentMethodTrait;
     use AuthorizeTransactionType;
     use RefundTransactionType;
+
     /**
      * Payment code for this payment method
      *
      * @var string payment code
      */
     protected $_paymentCode = 'OT';
-        
+
     /**
      * Payment brand name for this payment method
      *

--- a/lib/Push.php
+++ b/lib/Push.php
@@ -31,16 +31,16 @@ use SimpleXMLElement;
  *
  * Parses heidelpay Push Responses to a PhpApi Response object.
  *
- * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @license    Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright  Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *
- * @link https://dev.heidelpay.de/php-api
+ * @link       https://dev.heidelpay.de/php-api
  *
- * @author Stephano Vogel
+ * @author     Stephano Vogel
  *
- * @package heidelpay
+ * @package    heidelpay
  * @subpackage php-api
- * @category php-api
+ * @category   php-api
  */
 class Push
 {
@@ -158,6 +158,7 @@ class Push
      * return the class name of it.
      *
      * @param $parameterGroupInstance
+     *
      * @return string|null
      */
     private function getMappingClass($parameterGroupInstance)
@@ -171,6 +172,7 @@ class Push
      * Get the ParameterGroup Getters of the Response instance.
      *
      * @param Response $responseInstance
+     *
      * @return array
      */
     private function getResponseParameterGroups(Response $responseInstance)
@@ -190,6 +192,7 @@ class Push
      * Validates if the given getter is for a ParameterGroup.
      *
      * @param $methodName
+     *
      * @return bool
      */
     private function isParameterGroupGetter($methodName)

--- a/lib/Push.php
+++ b/lib/Push.php
@@ -5,6 +5,7 @@ namespace Heidelpay\PhpApi;
 use Heidelpay\PhpApi\ParameterGroups\AbstractParameterGroup;
 use Heidelpay\PhpApi\ParameterGroups\AccountParameterGroup;
 use Heidelpay\PhpApi\ParameterGroups\AddressParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\ConnectorParameterGroup;
 use Heidelpay\PhpApi\ParameterGroups\ContactParameterGroup;
 use Heidelpay\PhpApi\ParameterGroups\FrontendParameterGroup;
 use Heidelpay\PhpApi\ParameterGroups\IdentificationParameterGroup;
@@ -15,6 +16,7 @@ use Heidelpay\PhpApi\ParameterGroups\ProcessingParameterGroup;
 use Heidelpay\PhpApi\ParameterGroups\TransactionParameterGroup;
 use Heidelpay\PhpApi\PushMapping\Account;
 use Heidelpay\PhpApi\PushMapping\Address;
+use Heidelpay\PhpApi\PushMapping\Connector;
 use Heidelpay\PhpApi\PushMapping\Contact;
 use Heidelpay\PhpApi\PushMapping\Frontend;
 use Heidelpay\PhpApi\PushMapping\Identification;
@@ -67,6 +69,7 @@ class Push
     private $mapping = [
         AccountParameterGroup::class => Account::class,
         AddressParameterGroup::class => Address::class,
+        ConnectorParameterGroup::class => Connector::class,
         ContactParameterGroup::class => Contact::class,
         FrontendParameterGroup::class => Frontend::class,
         IdentificationParameterGroup::class => Identification::class,

--- a/lib/Push.php
+++ b/lib/Push.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Heidelpay\PhpApi;
+
+use Heidelpay\PhpApi\ParameterGroups\AbstractParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\AccountParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\AddressParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\ContactParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\FrontendParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\IdentificationParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\NameParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\PaymentParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\PresentationParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\ProcessingParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\TransactionParameterGroup;
+use Heidelpay\PhpApi\PushMapping\Account;
+use Heidelpay\PhpApi\PushMapping\Address;
+use Heidelpay\PhpApi\PushMapping\Contact;
+use Heidelpay\PhpApi\PushMapping\Frontend;
+use Heidelpay\PhpApi\PushMapping\Identification;
+use Heidelpay\PhpApi\PushMapping\Name;
+use Heidelpay\PhpApi\PushMapping\Payment;
+use Heidelpay\PhpApi\PushMapping\Presentation;
+use Heidelpay\PhpApi\PushMapping\Processing;
+use Heidelpay\PhpApi\PushMapping\PushMappingInterface;
+use Heidelpay\PhpApi\PushMapping\Transaction;
+use SimpleXMLElement;
+
+/**
+ * Push XML Mapper
+ *
+ * Parses heidelpay Push Responses to a PhpApi Response object.
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Push
+{
+    /**
+     * The raw XML response
+     *
+     * @var string
+     */
+    private $xmlResponse;
+
+    /**
+     * The PhpApi Response object that will be the result
+     *
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * Mapping array to determine which parameter group
+     * has to be mapped by which mapping class
+     *
+     * @var array
+     */
+    private $mapping = [
+        AccountParameterGroup::class => Account::class,
+        AddressParameterGroup::class => Address::class,
+        ContactParameterGroup::class => Contact::class,
+        FrontendParameterGroup::class => Frontend::class,
+        IdentificationParameterGroup::class => Identification::class,
+        NameParameterGroup::class => Name::class,
+        PaymentParameterGroup::class => Payment::class,
+        PresentationParameterGroup::class => Presentation::class,
+        ProcessingParameterGroup::class => Processing::class,
+        TransactionParameterGroup::class => Transaction::class
+    ];
+
+    /**
+     * Push constructor.
+     *
+     * @param string $xmlResponse a raw string in xml format
+     */
+    public function __construct($xmlResponse = null)
+    {
+        if ($xmlResponse !== null && is_string($xmlResponse)) {
+            $this->xmlResponse = $xmlResponse;
+            $this->parseXmlResponse();
+        }
+    }
+
+    /**
+     * If not setted in contructor, set the raw xml response
+     *
+     * @param string $response
+     */
+    public function setRawResponse(string $response)
+    {
+        $this->xmlResponse = $response;
+    }
+
+    /**
+     * Return the Response object
+     *
+     * If not set, parse the xml response and create the response.
+     * Then return it.
+     *
+     * @return Response
+     */
+    public function getResponse()
+    {
+        if ($this->response === null) {
+            $this->parseXmlResponse();
+        }
+
+        return $this->response;
+    }
+
+    /**
+     * Parses the raw XML response and maps the
+     * attributes to a PhpApi Response.
+     */
+    private function parseXmlResponse()
+    {
+        // initiate a new PhpApi Response.
+        $this->response = new Response();
+
+        try {
+            // get a new SimpleXML objects from the raw response.
+            $xml = new SimpleXMLElement($this->xmlResponse);
+
+            // loop though all Response getters
+            foreach ($this->getResponseParameterGroups($this->response) as $method) {
+                // get the instance of the parameter group by calling it's getter.
+                $parameterGroupInstance = call_user_func([$this->response, $method]);
+
+                // get the mapper class
+                if ($mapperClassName = $this->getMappingClass($parameterGroupInstance)) {
+                    $mapperInstance = new $mapperClassName;
+                    $this->setParameterGroupProperties($parameterGroupInstance, $mapperInstance, $xml);
+                }
+            }
+
+            // set the criterion data
+            if (isset($xml->Transaction->Analysis->Criterion)) {
+                foreach ($xml->Transaction->Analysis->Criterion as $criterion) {
+                    $this->response->getCriterion()->set($criterion['name'], (string)$criterion);
+                }
+            }
+        } catch (\Exception $e) {
+            throw new \Exception('Problem while parsing the raw xml response: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * If a Mapping Class for the given parameter group instance is given,
+     * return the class name of it.
+     *
+     * @param $parameterGroupInstance
+     * @return string|null
+     */
+    private function getMappingClass($parameterGroupInstance)
+    {
+        $className = get_class($parameterGroupInstance);
+
+        return isset($this->mapping[$className]) ? $this->mapping[$className] : null;
+    }
+
+    /**
+     * Get the ParameterGroup Getters of the Response instance.
+     *
+     * @param Response $responseInstance
+     * @return array
+     */
+    private function getResponseParameterGroups(Response $responseInstance)
+    {
+        $methods = [];
+
+        foreach (get_class_methods($responseInstance) as $method) {
+            if ($this->isParameterGroupGetter($method)) {
+                $methods[] = $method;
+            }
+        }
+
+        return $methods;
+    }
+
+    /**
+     * Validates if the given getter is for a ParameterGroup.
+     *
+     * @param $methodName
+     * @return bool
+     */
+    private function isParameterGroupGetter($methodName)
+    {
+        if ((substr($methodName, 0, 3) == 'get')
+            && ($methodName != 'getPaymentFormUrl') && ($methodName != 'getPaymentReferenceId')
+            && ($methodName != 'getError')
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Sets the properties of the ParameterGroup instance by mapping
+     * the attributes from the Mapping class
+     *
+     * @param AbstractParameterGroup $parameterGroupInstance
+     * @param PushMappingInterface $mappingClassInstance
+     * @param SimpleXMLElement $xmlResponse
+     */
+    private function setParameterGroupProperties(
+        AbstractParameterGroup &$parameterGroupInstance,
+        PushMappingInterface $mappingClassInstance,
+        SimpleXMLElement $xmlResponse
+    ) {
+        // set the Response properties according to the mapping properties => xml attributes.
+        foreach ($mappingClassInstance->getProperties() as $xmlProperty => $classField) {
+            if ($newValue = $mappingClassInstance->getXmlObjectProperty($xmlResponse, $xmlProperty)) {
+                $parameterGroupInstance->set($classField, $newValue);
+            }
+        }
+
+        // set the Response properties according to the mapping fields => xml tags.
+        foreach ($mappingClassInstance->getFields() as $xmlField => $classField) {
+            if ($newValue = $mappingClassInstance->getXmlObjectField($xmlResponse, $xmlField)) {
+                $parameterGroupInstance->set($classField, $newValue);
+            }
+        }
+
+        // set the Response properties according to the mapping xml field => attributes.
+        foreach ($mappingClassInstance->getFieldAttributes() as $xmlProperty => $classField) {
+            if ($newValue = $mappingClassInstance->getXmlObjectFieldAttribute($xmlResponse, $xmlProperty)) {
+                $parameterGroupInstance->set($classField, $newValue);
+            }
+        }
+    }
+}

--- a/lib/Push.php
+++ b/lib/Push.php
@@ -2,6 +2,8 @@
 
 namespace Heidelpay\PhpApi;
 
+use Heidelpay\PhpApi\Exceptions\UndefinedXmlResponseException;
+use Heidelpay\PhpApi\Exceptions\XmlResponseParserException;
 use Heidelpay\PhpApi\ParameterGroups\AbstractParameterGroup;
 use Heidelpay\PhpApi\ParameterGroups\AccountParameterGroup;
 use Heidelpay\PhpApi\ParameterGroups\AddressParameterGroup;
@@ -109,7 +111,7 @@ class Push
      * If not set, parse the xml response and create the response.
      * Then return it.
      *
-     * @return Response
+     * @return Response|null
      */
     public function getResponse()
     {
@@ -130,6 +132,10 @@ class Push
         $this->response = new Response();
 
         try {
+            if ($this->xmlResponse === null) {
+                throw new UndefinedXmlResponseException('XML Response is not set.');
+            }
+
             // get a new SimpleXML objects from the raw response.
             $xml = new SimpleXMLElement($this->xmlResponse);
 
@@ -152,7 +158,11 @@ class Push
                 }
             }
         } catch (\Exception $e) {
-            throw new \Exception('Problem while parsing the raw xml response: ' . $e->getMessage());
+            if ($e instanceof UndefinedXmlResponseException) {
+                throw new XmlResponseParserException('Problem while parsing the raw xml response: ' . $e->getMessage());
+            }
+
+            throw new \Exception($e->getMessage());
         }
     }
 

--- a/lib/Push.php
+++ b/lib/Push.php
@@ -209,8 +209,8 @@ class Push
      * the attributes from the Mapping class
      *
      * @param AbstractParameterGroup $parameterGroupInstance
-     * @param PushMappingInterface $mappingClassInstance
-     * @param SimpleXMLElement $xmlResponse
+     * @param PushMappingInterface   $mappingClassInstance
+     * @param SimpleXMLElement       $xmlResponse
      */
     private function setParameterGroupProperties(
         AbstractParameterGroup &$parameterGroupInstance,

--- a/lib/PushMapping/AbstractPushMapper.php
+++ b/lib/PushMapping/AbstractPushMapper.php
@@ -44,6 +44,7 @@ abstract class AbstractPushMapper implements PushMappingInterface
 
     /**
      * @param string $fieldName
+     *
      * @return string|null
      */
     public function getField($fieldName)
@@ -66,6 +67,7 @@ abstract class AbstractPushMapper implements PushMappingInterface
 
     /**
      * @param string $propertyName
+     *
      * @return array
      */
     public function getProperty($propertyName)

--- a/lib/PushMapping/AbstractPushMapper.php
+++ b/lib/PushMapping/AbstractPushMapper.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * Summary
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+abstract class AbstractPushMapper implements PushMappingInterface
+{
+    /**
+     * The XML tags that will be mapped, e.g. the <bank> property inside of <account>
+     * Syntax follows: 'XML Tag Name' => 'Class Field Name'
+     *
+     * @var array
+     */
+    public $fields = [];
+
+    /**
+     * The XML Field Attributes that will be mapped, e.g. <field attribute="">
+     * Syntax follows: 'Field:Attribute' => 'Class Field Name'
+     *
+     * @var array
+     */
+    public $fieldAttributes = [];
+
+    /**
+     * The XML properties that will be mapped, e.g. the 'name' property in <account name="">
+     * Syntax follows: 'XML Property Name' => 'Class Field Name'
+     *
+     * @var array
+     */
+    public $properties = [];
+
+    /**
+     * @param string $fieldName
+     * @return string|null
+     */
+    public function getField($fieldName)
+    {
+        return isset($this->fields[$fieldName]) ? $this->fields[$fieldName] : null;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFields()
+    {
+        return is_array($this->fields) ? $this->fields : [];
+    }
+
+    public function getFieldAttributes()
+    {
+        return is_array($this->fieldAttributes) ? $this->fieldAttributes : [];
+    }
+
+    /**
+     * @param string $propertyName
+     * @return array
+     */
+    public function getProperty($propertyName)
+    {
+        return isset($this->properties[$propertyName]) ? $this->properties[$propertyName] : null;
+    }
+
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        return is_array($this->properties) ? $this->properties : [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
+    {
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getXmlObjectFieldAttribute(\SimpleXMLElement $xmlElement, $field)
+    {
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getXmlObjectProperty(\SimpleXMLElement $xmlElement, $property)
+    {
+        return null;
+    }
+}

--- a/lib/PushMapping/Account.php
+++ b/lib/PushMapping/Account.php
@@ -30,10 +30,26 @@ class Account extends AbstractPushMapper
         'Number' => 'number',
     ];
 
+    public $fieldAttributes = [
+        'Expiry:year' => 'expiry_year',
+        'Expiry:month' => 'expiry_month',
+    ];
+
     public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
     {
         if (isset($xmlElement->Transaction->Account->$field)) {
             return (string)$xmlElement->Transaction->Account->$field;
+        }
+
+        return null;
+    }
+
+    public function getXmlObjectFieldAttribute(\SimpleXMLElement $xmlElement, $fieldAttribute)
+    {
+        list($field, $attribute) = explode(':', $fieldAttribute);
+
+        if (isset($xmlElement->Transaction->Account->$field[$attribute])) {
+            return (string)$xmlElement->Transaction->Account->$field[$attribute];
         }
 
         return null;

--- a/lib/PushMapping/Account.php
+++ b/lib/PushMapping/Account.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * XML Push Mapping Class for Account Parameter Group
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Account extends AbstractPushMapper
+{
+    public $fields = [
+        'Bank' => 'bank',
+        'BankName' => 'bankname',
+        'Brand' => 'brand',
+        'Bic' => 'bic',
+        'Country' => 'country',
+        'Holder' => 'holder',
+        'Iban' => 'iban',
+        'Identification' => 'identification',
+        'Number' => 'number',
+    ];
+
+    public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
+    {
+        if (isset($xmlElement->Transaction->Account->$field)) {
+            return (string)$xmlElement->Transaction->Account->$field;
+        }
+
+        return null;
+    }
+}

--- a/lib/PushMapping/Address.php
+++ b/lib/PushMapping/Address.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * Summary
+ *
+ * Desc
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Address extends AbstractPushMapper
+{
+    public $fields = [
+        'City' => 'city',
+        'Country' => 'country',
+        'State' => 'state',
+        'Street' => 'street',
+        'Zip' => 'zip',
+    ];
+
+    public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
+    {
+        if (isset($xmlElement->Transaction->Customer->Address->$field)) {
+            return (string) $xmlElement->Transaction->Customer->Address->$field;
+        }
+
+        return null;
+    }
+}

--- a/lib/PushMapping/Connector.php
+++ b/lib/PushMapping/Connector.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * Summary
+ *
+ * @license    Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright  Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link       https://dev.heidelpay.de/php-api
+ *
+ * @author     Stephano Vogel
+ *
+ * @package    heidelpay
+ * @subpackage php-api
+ * @category   php-api
+ */
+class Connector extends AbstractPushMapper
+{
+    public $fields = [
+        'Bank' => 'account_bank',
+        'Bic' => 'account_bic',
+        'Country' => 'account_country',
+        'Holder' => 'account_holder',
+        'Iban' => 'account_iban',
+        'Number' => 'account_number',
+    ];
+
+    public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
+    {
+        if (isset($xmlElement->Transaction->Connector->Account->$field)) {
+            return (string) $xmlElement->Transaction->Connector->Account->$field;
+        }
+
+        return null;
+    }
+}

--- a/lib/PushMapping/Contact.php
+++ b/lib/PushMapping/Contact.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * Summary
+ *
+ * Desc
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Contact extends AbstractPushMapper
+{
+    public $fields = [
+        'Email' => 'email',
+        'Ip' => 'ip',
+        'Mobile' => 'mobile',
+        'Phone' => 'phone',
+    ];
+
+    public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
+    {
+        if (isset($xmlElement->Transaction->Customer->Contact->$field)) {
+            return (string)$xmlElement->Transaction->Customer->Contact->$field;
+        }
+
+        return null;
+    }
+}

--- a/lib/PushMapping/Frontend.php
+++ b/lib/PushMapping/Frontend.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * Summary
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Frontend extends AbstractPushMapper
+{
+    public $fields = [
+        'CssPath' => 'css_path',
+        'Enabled' => 'enabled',
+        'Language' => 'language',
+        'Mode' => 'mode',
+        'PaymentFrameUrl' => 'payment_frame_url',
+        'PreventAsyncRedirect' => 'prevent_async_redirect',
+        'RedirectUrl' => 'redirect_url',
+        'ResponseUrl' => 'response_url',
+    ];
+
+    public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
+    {
+        if (isset($xmlElement->Transaction->Frontend->$field)) {
+            return (string)$xmlElement->Transaction->Frontend->$field;
+        }
+
+        return null;
+    }
+}

--- a/lib/PushMapping/Identification.php
+++ b/lib/PushMapping/Identification.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * Summary
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Identification extends AbstractPushMapper
+{
+    public $fields = [
+        'CreditorID' => 'creditor_id',
+        'ReferenceID' => 'referenceid',
+        'ShopperID' => 'shopperid',
+        'ShortID' => 'shortid',
+        'TransactionID' => 'transactionid',
+        'UniqueID' => 'uniqueid',
+    ];
+
+    public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
+    {
+        if (isset($xmlElement->Transaction->Identification->$field)) {
+            return (string)$xmlElement->Transaction->Identification->$field;
+        }
+
+        return null;
+    }
+}

--- a/lib/PushMapping/Name.php
+++ b/lib/PushMapping/Name.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * XML Push Mapping Class for Name Parameter Group
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Name extends AbstractPushMapper
+{
+    public $fields = [
+        'Birthdate' => 'birthdate',
+        'Company' => 'company',
+        'Family' => 'family',
+        'Given' => 'given',
+        'Salutation' => 'salutation',
+        'Title' => 'title',
+    ];
+
+    public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
+    {
+        if (isset($xmlElement->Transaction->Customer->Name->$field)) {
+            return (string)$xmlElement->Transaction->Customer->Name->$field;
+        }
+
+        return null;
+    }
+}

--- a/lib/PushMapping/Payment.php
+++ b/lib/PushMapping/Payment.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * Summary
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Payment extends AbstractPushMapper
+{
+    public $properties = [
+        'code' => 'code',
+    ];
+
+    public function getXmlObjectProperty(\SimpleXMLElement $xmlElement, $property)
+    {
+        if (isset($xmlElement->Transaction->Payment[$property])) {
+            return (string)$xmlElement->Transaction->Payment[$property];
+        }
+
+        return null;
+    }
+}

--- a/lib/PushMapping/Presentation.php
+++ b/lib/PushMapping/Presentation.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * Summary
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Presentation extends AbstractPushMapper
+{
+    public $fields = [
+        'Amount' => 'amount',
+        'Currency' => 'currency',
+        'Usage' => 'usage',
+    ];
+
+    public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
+    {
+        if (isset($xmlElement->Transaction->Payment->Presentation->$field)) {
+            return (string)$xmlElement->Transaction->Payment->Presentation->$field;
+        }
+
+        return null;
+    }
+
+    public function getXmlObjectProperty(\SimpleXMLElement $xmlElement, $property)
+    {
+        if (isset($xmlElement->Transaction->Payment->Presentation[$property])) {
+            return (string)$xmlElement->Transaction->Payment->Presentation[$property];
+        }
+
+        return null;
+    }
+}

--- a/lib/PushMapping/Processing.php
+++ b/lib/PushMapping/Processing.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * Summary
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Processing extends AbstractPushMapper
+{
+    public $fields = [
+        'ConfirmationStatus' => 'confirmation_status',
+        'Reason' => 'reason',
+        'Result' => 'result',
+        'Return' => 'return',
+        'Status' => 'status',
+        'Timestamp' => 'timestamp',
+    ];
+
+    public $fieldAttributes = [
+        'Reason:code' => 'reason_code',
+        'Return:code' => 'return_code',
+        'Status:code' => 'status_code',
+    ];
+
+    public $properties = [
+        'code' => 'code'
+    ];
+
+    public function getXmlObjectField(\SimpleXMLElement $xmlElement, $field)
+    {
+        if (isset($xmlElement->Transaction->Processing->$field)) {
+            return (string)$xmlElement->Transaction->Processing->$field;
+        }
+
+        return null;
+    }
+
+    public function getXmlObjectFieldAttribute(\SimpleXMLElement $xmlElement, $fieldAttribute)
+    {
+        list($field, $attribute) = explode(':', $fieldAttribute);
+
+        if (isset($xmlElement->Transaction->Processing->$field[$attribute])) {
+            return (string)$xmlElement->Transaction->Processing->$field[$attribute];
+        }
+
+        return null;
+    }
+
+    public function getXmlObjectProperty(\SimpleXMLElement $xmlElement, $property)
+    {
+        if (isset($xmlElement->Transaction->Processing[$property])) {
+            $result = (string)$xmlElement->Transaction->Processing[$property];
+
+            // temporary solution: code in xml response contents too much, we cut it here.
+            if ($property == 'code') {
+                $codeRaw = explode('.', $result);
+                $result = $codeRaw[0] . '.' . $codeRaw[1];
+            }
+
+            return $result;
+        }
+
+        return null;
+    }
+}

--- a/lib/PushMapping/PushMappingInterface.php
+++ b/lib/PushMapping/PushMappingInterface.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+use SimpleXMLElement;
+
+/**
+ * Interface for Push Mapping classes
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+interface PushMappingInterface
+{
+    /**
+     * Returns the field properties of the mapping class.
+     *
+     * @return array
+     */
+    public function getFields();
+
+    /**
+     * Returns an array of field attributes.
+     *
+     * @return array
+     */
+    public function getFieldAttributes();
+
+    /**
+     * Returns the properties of the mapping class.
+     *
+     * @return array
+     */
+    public function getProperties();
+
+    /**
+     * Method to retrieve the mapped SimpleXMLElement tag content.
+     *
+     * @param SimpleXMLElement $xmlElement
+     * @param string $field
+     * @return string|null
+     */
+    public function getXmlObjectField(SimpleXMLElement $xmlElement, $field);
+
+    /**
+     * Method to retrieve a mapped SimpleXMLElement field attribute.
+     *
+     * @param SimpleXMLElement $xmlElement
+     * @param string $field
+     * @return string|null
+     */
+    public function getXmlObjectFieldAttribute(SimpleXMLElement $xmlElement, $field);
+
+    /**
+     * Method to retrieve the mapped SimpleXMLElement tag property.
+     *
+     * @param SimpleXMLElement $xmlElement
+     * @param string $property
+     * @return string|null
+     */
+    public function getXmlObjectProperty(SimpleXMLElement $xmlElement, $property);
+}

--- a/lib/PushMapping/PushMappingInterface.php
+++ b/lib/PushMapping/PushMappingInterface.php
@@ -45,7 +45,8 @@ interface PushMappingInterface
      * Method to retrieve the mapped SimpleXMLElement tag content.
      *
      * @param SimpleXMLElement $xmlElement
-     * @param string $field
+     * @param string           $field
+     *
      * @return string|null
      */
     public function getXmlObjectField(SimpleXMLElement $xmlElement, $field);
@@ -54,7 +55,8 @@ interface PushMappingInterface
      * Method to retrieve a mapped SimpleXMLElement field attribute.
      *
      * @param SimpleXMLElement $xmlElement
-     * @param string $field
+     * @param string           $field
+     *
      * @return string|null
      */
     public function getXmlObjectFieldAttribute(SimpleXMLElement $xmlElement, $field);
@@ -63,7 +65,8 @@ interface PushMappingInterface
      * Method to retrieve the mapped SimpleXMLElement tag property.
      *
      * @param SimpleXMLElement $xmlElement
-     * @param string $property
+     * @param string           $property
+     *
      * @return string|null
      */
     public function getXmlObjectProperty(SimpleXMLElement $xmlElement, $property);

--- a/lib/PushMapping/Transaction.php
+++ b/lib/PushMapping/Transaction.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Heidelpay\PhpApi\PushMapping;
+
+/**
+ * XML Push Mapping Class for Transaction Parameter Group
+ *
+ * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
+ * @link https://dev.heidelpay.de/php-api
+ *
+ * @author Stephano Vogel
+ *
+ * @package heidelpay
+ * @subpackage php-api
+ * @category php-api
+ */
+class Transaction extends AbstractPushMapper
+{
+    public $properties = [
+        'channel' => 'channel',
+        'mode' => 'mode',
+    ];
+
+    public function getXmlObjectProperty(\SimpleXMLElement $xmlElement, $property)
+    {
+        if (isset($xmlElement->Transaction[$property])) {
+            return (string)$xmlElement->Transaction[$property];
+        }
+
+        return null;
+    }
+}

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace Heidelpay\PhpApi;
+
+use Heidelpay\PhpApi\Adapter\CurlAdapter;
 
 /**
  * Heidelpay request object
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -23,16 +25,16 @@ class Request extends AbstractMethod
      */
     public function __construct()
     {
-        $this->criterion        = $this->getCriterion();
-        $this->frontend         = $this->getFrontend();
-        $this->identification   = $this->getIdentification();
-        $this->presentation     = $this->getPresentation();
-        $this->request          = $this->getRequest();
-        $this->security         = $this->getSecurity();
-        $this->transaction      = $this->getTransaction();
-        $this->user             = $this->getUser();
+        $this->criterion = $this->getCriterion();
+        $this->frontend = $this->getFrontend();
+        $this->identification = $this->getIdentification();
+        $this->presentation = $this->getPresentation();
+        $this->request = $this->getRequest();
+        $this->security = $this->getSecurity();
+        $this->transaction = $this->getTransaction();
+        $this->user = $this->getUser();
     }
-    
+
     /**
      * Set all necessary authentication parameters for this request
      *
@@ -40,22 +42,28 @@ class Request extends AbstractMethod
      * @param string $UserLogin
      * @param string $UserPassword
      * @param string $TransactionChannel
-     * @param bool   $SandboxRequest
+     * @param bool $SandboxRequest
+     * @return \Heidelpay\PhpApi\Request
      */
-    public function authentification($SecuritySender=null, $UserLogin=null, $UserPassword=null, $TransactionChannel=null, $SandboxRequest=false)
-    {
+    public function authentification(
+        $SecuritySender = null,
+        $UserLogin = null,
+        $UserPassword = null,
+        $TransactionChannel = null,
+        $SandboxRequest = false
+    ) {
         $this->getSecurity()->set('sender', $SecuritySender);
         $this->getUser()->set('login', $UserLogin);
         $this->getUser()->set('pwd', $UserPassword);
         $this->getTransaction()->set('channel', $TransactionChannel);
         $this->getTransaction()->set('mode', "LIVE");
-        
+
         if ($SandboxRequest) {
             $this->getTransaction()->set('mode', "CONNECTOR_TEST");
         }
-        return  $this;
+        return $this;
     }
-    
+
     /**
      * Set all necessary parameter for a asynchronous request
      *
@@ -64,17 +72,17 @@ class Request extends AbstractMethod
      *
      * @return \Heidelpay\PhpApi\Request
      */
-    public function async($LanguageCode="EN", $ResponseUrl=null)
+    public function async($LanguageCode = "EN", $ResponseUrl = null)
     {
         $this->getFrontend()->set('language', $LanguageCode);
-        
+
         if ($ResponseUrl !== null) {
             $this->getFrontend()->set('response_url', $ResponseUrl);
             $this->getFrontend()->set('enabled', 'TRUE');
         }
-        return  $this;
+        return $this;
     }
-    
+
     /**
      * Set all necessary customer parameter for a request
      *
@@ -91,8 +99,18 @@ class Request extends AbstractMethod
      *
      * @return \Heidelpay\PhpApi\Request
      */
-    public function customerAddress($nameGiven=null, $nameFamily=null, $nameCompany=null, $shopperId=null, $addressStreet=null, $addressState=null, $addressZip=null, $addressCity=null, $addressCountry=null, $contactMail=null)
-    {
+    public function customerAddress(
+        $nameGiven = null,
+        $nameFamily = null,
+        $nameCompany = null,
+        $shopperId = null,
+        $addressStreet = null,
+        $addressState = null,
+        $addressZip = null,
+        $addressCity = null,
+        $addressCountry = null,
+        $contactMail = null
+    ) {
         $this->getName()->set('given', $nameGiven);
         $this->getName()->set('family', $nameFamily);
         $this->getName()->set('company', $nameCompany);
@@ -103,10 +121,10 @@ class Request extends AbstractMethod
         $this->getAddress()->set('city', $addressCity);
         $this->getAddress()->set('country', $addressCountry);
         $this->getContact()->set('email', $contactMail);
-        
-        return  $this;
+
+        return $this;
     }
-    
+
     /**
      * Set all basket or order information
      *
@@ -117,7 +135,7 @@ class Request extends AbstractMethod
      *
      * @return \Heidelpay\PhpApi\Request
      */
-    public function basketData($shopIdentifier=null, $amount=null, $currency=null, $secret=null)
+    public function basketData($shopIdentifier = null, $amount = null, $currency = null, $secret = null)
     {
         $this->getIdentification()->set('transactionid', $shopIdentifier);
         $this->getPresentation()->set('amount', $amount);
@@ -125,10 +143,10 @@ class Request extends AbstractMethod
         if ($secret !== null and $shopIdentifier !== null) {
             $this->getCriterion()->setSecret($shopIdentifier, $secret);
         }
-        
+
         return $this;
     }
-    
+
     /**
      * Convert request object to post key value format
      *
@@ -137,35 +155,35 @@ class Request extends AbstractMethod
     public function convertToArray()
     {
         $array = array();
-        $request = (array) get_object_vars($this);
-        
+        $request = (array)get_object_vars($this);
+
         foreach ($request as $ParameterFirstName => $ParmaterValues) {
             if ($ParmaterValues === null) {
                 continue;
             }
-            
+
             foreach ((array)get_object_vars($ParmaterValues) as $ParameterLastName => $ParameterValue) {
                 if ($ParameterValue === null) {
                     continue;
                 }
-                $array[strtoupper($ParameterFirstName.'.'.$ParameterLastName)] = $ParameterValue;
+                $array[strtoupper($ParameterFirstName . '.' . $ParameterLastName)] = $ParameterValue;
             }
         }
         return $array;
     }
-    
+
     /**
      * Send request to payment api
      *
-     * @param string $uri  payment api url
-     * @param array  $post heidelpay request parameter
+     * @param string $uri payment api url
+     * @param array $post heidelpay request parameter
      * @param \Heidelpay\PhpApi\Adapter\\$adapter
      *
      * @return array response|\Heidelpay\PhpApi\Response
      */
-    public function send($uri=null, $post=null, $adapter=null)
+    public function send($uri = null, $post = null, $adapter = null)
     {
-        $client = new \Heidelpay\PhpApi\Adapter\CurlAdapter();
+        $client = new CurlAdapter();
 
         if ($adapter !== null) {
             $client = new $adapter;
@@ -178,12 +196,12 @@ class Request extends AbstractMethod
      * Parameter used in case of b2c secured invoice or direct debit
      *
      * @param null $salutation customer salutation MR/MRS (Mandatory)
-     * @param null $birthdate  customer birth date YYYY-MM-DD (Mandatory)
-     * @param null $basketId   id of a given basket using heidelpay basket api (Optional)
+     * @param null $birthdate customer birth date YYYY-MM-DD (Mandatory)
+     * @param null $basketId id of a given basket using heidelpay basket api (Optional)
      *
      * @return $this \Heidelpay\PhpApi\Request
      */
-    public function b2cSecured($salutation=null, $birthdate=null, $basketId=null)
+    public function b2cSecured($salutation = null, $birthdate = null, $basketId = null)
     {
         $this->getName()->set('salutation', $salutation);
         $this->getName()->set('birthdate', $birthdate);

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -42,7 +42,8 @@ class Request extends AbstractMethod
      * @param string $UserLogin
      * @param string $UserPassword
      * @param string $TransactionChannel
-     * @param bool $SandboxRequest
+     * @param bool   $SandboxRequest
+     *
      * @return \Heidelpay\PhpApi\Request
      */
     public function authentification(
@@ -176,7 +177,7 @@ class Request extends AbstractMethod
      * Send request to payment api
      *
      * @param string $uri payment api url
-     * @param array $post heidelpay request parameter
+     * @param array  $post heidelpay request parameter
      * @param \Heidelpay\PhpApi\Adapter\\$adapter
      *
      * @return array response|\Heidelpay\PhpApi\Response

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -176,8 +176,8 @@ class Request extends AbstractMethod
     /**
      * Send request to payment api
      *
-     * @param string                                $uri  payment api url
-     * @param array                                 $post heidelpay request parameter
+     * @param string                                $uri     payment api url
+     * @param array                                 $post    heidelpay request parameter
      * @param \Heidelpay\PhpApi\Adapter\CurlAdapter $adapter
      *
      * @return array response|\Heidelpay\PhpApi\Response

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -7,16 +7,16 @@ use Heidelpay\PhpApi\Adapter\CurlAdapter;
 /**
  * Heidelpay request object
  *
- * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @license    Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ * @copyright  Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *
- * @link  https://dev.heidelpay.de/PhpApi
+ * @link       https://dev.heidelpay.de/PhpApi
  *
- * @author  Jens Richter
+ * @author     Jens Richter
  *
- * @package  Heidelpay
+ * @package    Heidelpay
  * @subpackage PhpApi
- * @category PhpApi
+ * @category   PhpApi
  */
 class Request extends AbstractMethod
 {
@@ -176,9 +176,9 @@ class Request extends AbstractMethod
     /**
      * Send request to payment api
      *
-     * @param string $uri payment api url
-     * @param array  $post heidelpay request parameter
-     * @param \Heidelpay\PhpApi\Adapter\\$adapter
+     * @param string                                $uri  payment api url
+     * @param array                                 $post heidelpay request parameter
+     * @param \Heidelpay\PhpApi\Adapter\CurlAdapter $adapter
      *
      * @return array response|\Heidelpay\PhpApi\Response
      */
@@ -197,8 +197,8 @@ class Request extends AbstractMethod
      * Parameter used in case of b2c secured invoice or direct debit
      *
      * @param null $salutation customer salutation MR/MRS (Mandatory)
-     * @param null $birthdate customer birth date YYYY-MM-DD (Mandatory)
-     * @param null $basketId id of a given basket using heidelpay basket api (Optional)
+     * @param null $birthdate  customer birth date YYYY-MM-DD (Mandatory)
+     * @param null $basketId   id of a given basket using heidelpay basket api (Optional)
      *
      * @return $this \Heidelpay\PhpApi\Request
      */

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -10,16 +10,16 @@ use Heidelpay\PhpApi\ParameterGroups\ProcessingParameterGroup;
 /**
  * Heidelpay response object
  *
- * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @license    Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ * @copyright  Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *
- * @link  https://dev.heidelpay.de/PhpApi
+ * @link       https://dev.heidelpay.de/PhpApi
  *
- * @author  Jens Richter
+ * @author     Jens Richter
  *
- * @package  Heidelpay
+ * @package    Heidelpay
  * @subpackage PhpApi
- * @category PhpApi
+ * @category   PhpApi
  */
 class Response extends AbstractMethod
 {

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -23,7 +23,6 @@ use Heidelpay\PhpApi\ParameterGroups\ProcessingParameterGroup;
  */
 class Response extends AbstractMethod
 {
-
     /**
      * ConnectorParameterGroup
      *
@@ -260,7 +259,7 @@ class Response extends AbstractMethod
      * response to your system. Please verify the source of the response. If it
      * is a legal one, it can be some kind of misconfiguration.
      *
-     * @param string $secret of your application
+     * @param string $secret                      your application's secret hash
      * @param string $identificationTransactionId basket or order reference id
      *
      * @throws \Exception

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -218,6 +218,7 @@ class Response extends AbstractMethod
      * be the iframe url.
      *
      * @return string PaymentFormUrl
+     *
      * @throws PaymentFormUrlException
      */
     public function getPaymentFormUrl()

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -1,9 +1,14 @@
 <?php
+
 namespace Heidelpay\PhpApi;
+
+use Heidelpay\PhpApi\Exceptions\HashVerificationException;
+use Heidelpay\PhpApi\Exceptions\PaymentFormUrlException;
+use Heidelpay\PhpApi\ParameterGroups\ConnectorParameterGroup;
+use Heidelpay\PhpApi\ParameterGroups\ProcessingParameterGroup;
 
 /**
  * Heidelpay response object
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -16,9 +21,6 @@ namespace Heidelpay\PhpApi;
  * @subpackage PhpApi
  * @category PhpApi
  */
-use Heidelpay\PhpApi\Exceptions\HashVerificationException;
-use Heidelpay\PhpApi\Exceptions\PaymentFormUrlException;
-
 class Response extends AbstractMethod
 {
 
@@ -57,7 +59,7 @@ class Response extends AbstractMethod
     public function getProcessing()
     {
         if ($this->processing === null) {
-            return $this->processing = new \Heidelpay\PhpApi\ParameterGroups\ProcessingParameterGroup();
+            return $this->processing = new ProcessingParameterGroup();
         }
 
         return $this->processing;
@@ -71,7 +73,7 @@ class Response extends AbstractMethod
     public function getConnector()
     {
         if ($this->connector === null) {
-            return $this->connector = new \Heidelpay\PhpApi\ParameterGroups\ConnectorParameterGroup();
+            return $this->connector = new ConnectorParameterGroup();
         }
 
         return $this->connector;
@@ -194,7 +196,8 @@ class Response extends AbstractMethod
      */
     public function getError()
     {
-        return array('code' => $this->getProcessing()->getReturnCode(),
+        return array(
+            'code' => $this->getProcessing()->getReturnCode(),
             'message' => $this->getProcessing()->getReturn()
         );
     }
@@ -215,14 +218,15 @@ class Response extends AbstractMethod
      * Used to create the payment form. In case of credit/debit card it will
      * be the iframe url.
      *
-     * @return string|boolean PaymentFormUrl
+     * @return string PaymentFormUrl
+     * @throws PaymentFormUrlException
      */
     public function getPaymentFormUrl()
     {
         /*
          * PaymentFrameUrl for credit and debitcard
          */
-        $code =  null;
+        $code = null;
         $type = null;
 
         if ($this->getPayment()->getCode() === null) {
@@ -233,17 +237,18 @@ class Response extends AbstractMethod
 
         if (($code == 'CC' or $code == 'DC')
             and $this->getIdentification()->getReferenceId() === null
-            and $this->getFrontend()->getPaymentFrameUrl() !== null) {
+            and $this->getFrontend()->getPaymentFrameUrl() !== null
+        ) {
             return $this->getFrontend()->getPaymentFrameUrl();
         }
 
-         /*
-          * Redirect url
-          */
+        /*
+         * Redirect url
+         */
 
-         if ($this->getFrontend()->getRedirectUrl() !== null) {
-             return $this->getFrontend()->getRedirectUrl();
-         }
+        if ($this->getFrontend()->getRedirectUrl() !== null) {
+            return $this->getFrontend()->getRedirectUrl();
+        }
 
         throw new PaymentFormUrlException('PaymentFromUrl is unset!');
     }
@@ -251,12 +256,11 @@ class Response extends AbstractMethod
     /**
      * Verify that the response secret hash matches the one given by initial request
      *
-     *  A mismatch can be a indication, that someone tries to send fake payment
-     *  response to your system. Please verify the source of the response. If it
-     *  is a legal one, it can be some kind of misconfiguration.
+     * A mismatch can be a indication, that someone tries to send fake payment
+     * response to your system. Please verify the source of the response. If it
+     * is a legal one, it can be some kind of misconfiguration.
      *
-     *
-     * @param string $secret                      of your application
+     * @param string $secret of your application
      * @param string $identificationTransactionId basket or order reference id
      *
      * @throws \Exception
@@ -270,11 +274,15 @@ class Response extends AbstractMethod
         }
 
         if ($this->getProcessing()->getResult() === null) {
-            throw new HashVerificationException('The response object seems to be empty or it is not a valid heidelpay response!');
+            throw new HashVerificationException(
+                'The response object seems to be empty or it is not a valid heidelpay response!'
+            );
         }
 
         if ($this->getCriterion()->getSecretHash() === null) {
-            throw new HashVerificationException('Empty secret hash, this could be some kind of manipulation or misconfiguration!');
+            throw new HashVerificationException(
+                'Empty secret hash, this could be some kind of manipulation or misconfiguration!'
+            );
         }
 
         $referenceHash = hash('sha512', $identificationTransactionId . $secret);
@@ -283,6 +291,8 @@ class Response extends AbstractMethod
             return true;
         }
 
-        throw new HashVerificationException('Hash does not match. This could be some kind of manipulation or misconfiguration!');
+        throw new HashVerificationException(
+            'Hash does not match. This could be some kind of manipulation or misconfiguration!'
+        );
     }
 }

--- a/lib/TransactionTypes/AuthorizeOnRegistrationTransactionType.php
+++ b/lib/TransactionTypes/AuthorizeOnRegistrationTransactionType.php
@@ -26,6 +26,7 @@ trait AuthorizeOnRegistrationTransactionType
      * This payment type will be used to make an authorisation on a given registration.
      *
      * @param string $PaymentReferenceId (unique id of the registration)
+     *
      * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function authorizeOnRegistration($PaymentReferenceId)

--- a/lib/TransactionTypes/AuthorizeOnRegistrationTransactionType.php
+++ b/lib/TransactionTypes/AuthorizeOnRegistrationTransactionType.php
@@ -25,10 +25,8 @@ trait AuthorizeOnRegistrationTransactionType
      *
      * This payment type will be used to make an authorisation on a given registration.
      *
-     * @param string payment reference id (unique id of the registration)
-     * @param mixed $PaymentReferenceId
-     *
-     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
+     * @param string $PaymentReferenceId (unique id of the registration)
+     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function authorizeOnRegistration($PaymentReferenceId)
     {

--- a/lib/TransactionTypes/AuthorizeTransactionType.php
+++ b/lib/TransactionTypes/AuthorizeTransactionType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\TransactionTypes;
 
 /**
@@ -30,12 +31,13 @@ trait AuthorizeTransactionType
      * like Sofort and Giropay (so called online payments) this type will be
      * used just to get the redirect to their systems.
      *
-     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
+     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function authorize()
     {
-        $this->getRequest()->getPayment()->set('code', $this->_paymentCode.".PA");
+        $this->getRequest()->getPayment()->set('code', $this->_paymentCode . ".PA");
         $this->prepareRequest();
+
         return $this;
     }
 }

--- a/lib/TransactionTypes/CaptureTransactionType.php
+++ b/lib/TransactionTypes/CaptureTransactionType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\TransactionTypes;
 
 /**
@@ -24,17 +25,16 @@ trait CaptureTransactionType
      *
      * You can charge a given authorisation by capturing the transaction.
      *
-     * @param string payment reference id ( unique id of the authorisation )
-     * @param mixed $PaymentReferenceId
-     *
-     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
+     * @param string $PaymentReferenceId ( unique id of the authorisation )
+     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function capture($PaymentReferenceId)
     {
-        $this->getRequest()->getPayment()->set('code', $this->_paymentCode.".CP");
+        $this->getRequest()->getPayment()->set('code', $this->_paymentCode . ".CP");
         $this->getRequest()->getFrontend()->set('enabled', 'FALSE');
         $this->getRequest()->getIdentification()->set('referenceId', $PaymentReferenceId);
         $this->prepareRequest();
+
         return $this;
     }
 }

--- a/lib/TransactionTypes/CaptureTransactionType.php
+++ b/lib/TransactionTypes/CaptureTransactionType.php
@@ -26,6 +26,7 @@ trait CaptureTransactionType
      * You can charge a given authorisation by capturing the transaction.
      *
      * @param string $PaymentReferenceId ( unique id of the authorisation )
+     *
      * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function capture($PaymentReferenceId)

--- a/lib/TransactionTypes/DebitOnRegistrationTransactionType.php
+++ b/lib/TransactionTypes/DebitOnRegistrationTransactionType.php
@@ -27,9 +27,7 @@ trait DebitOnRegistrationTransactionType
      * This payment type will charge the given account directly. The debit is
      * related to a registration.
      *
-     * @param string payment reference id ( unique id of the registration
-     * @param mixed $PaymentReferenceId
-     *
+     * @param string $PaymentReferenceId ( unique id of the registration
      * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
      */
     public function debitOnRegistration($PaymentReferenceId)

--- a/lib/TransactionTypes/DebitOnRegistrationTransactionType.php
+++ b/lib/TransactionTypes/DebitOnRegistrationTransactionType.php
@@ -28,6 +28,7 @@ trait DebitOnRegistrationTransactionType
      * related to a registration.
      *
      * @param string $PaymentReferenceId ( unique id of the registration
+     *
      * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
      */
     public function debitOnRegistration($PaymentReferenceId)

--- a/lib/TransactionTypes/DebitTransactionType.php
+++ b/lib/TransactionTypes/DebitTransactionType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\TransactionTypes;
 
 /**
@@ -24,12 +25,13 @@ trait DebitTransactionType
      *
      * This payment type will charge the given account directly.
      *
-     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
+     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function debit()
     {
-        $this->getRequest()->getPayment()->set('code', $this->_paymentCode.".DB");
+        $this->getRequest()->getPayment()->set('code', $this->_paymentCode . ".DB");
         $this->prepareRequest();
+
         return $this;
     }
 }

--- a/lib/TransactionTypes/FinalizeTransactionType.php
+++ b/lib/TransactionTypes/FinalizeTransactionType.php
@@ -29,7 +29,7 @@ trait FinalizeTransactionType
      *
      * @param mixed $PaymentReferenceId reference id ( uniqe id of the debit or capture)
      *
-     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
+     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function finalize($PaymentReferenceId)
     {
@@ -37,6 +37,7 @@ trait FinalizeTransactionType
         $this->getRequest()->getFrontend()->set('enabled', 'FALSE');
         $this->getRequest()->getIdentification()->set('referenceId', $PaymentReferenceId);
         $this->prepareRequest();
+
         return $this;
     }
 }

--- a/lib/TransactionTypes/RebillTransactionType.php
+++ b/lib/TransactionTypes/RebillTransactionType.php
@@ -29,17 +29,17 @@ trait RebillTransactionType
      * example, in case of a higher shipping cost. Please make sure that you
      * have the permission of your customer to charge again.
      *
-     * @param string payment reference id ( unique id of the debit or capture )
-     * @param mixed $PaymentReferenceId
+     * @param string $PaymentReferenceId ( unique id of the debit or capture )
      *
      * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
      */
     public function rebill($PaymentReferenceId)
     {
-        $this->getRequest()->getPayment()->set('code', $this->_paymentCode.".RB");
+        $this->getRequest()->getPayment()->set('code', $this->_paymentCode . ".RB");
         $this->getRequest()->getFrontend()->set('enabled', 'FALSE');
         $this->getRequest()->getIdentification()->set('referenceId', $PaymentReferenceId);
         $this->prepareRequest();
+
         return $this;
     }
 }

--- a/lib/TransactionTypes/RefundTransactionType.php
+++ b/lib/TransactionTypes/RefundTransactionType.php
@@ -28,8 +28,7 @@ trait RefundTransactionType
      * it back to the given account.
      *
      * @param mixed $PaymentReferenceId payment reference id ( uniqe id of the debit or capture)
-     *
-     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
+     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function refund($PaymentReferenceId)
     {
@@ -37,6 +36,7 @@ trait RefundTransactionType
         $this->getRequest()->getFrontend()->set('enabled', 'FALSE');
         $this->getRequest()->getIdentification()->set('referenceId', $PaymentReferenceId);
         $this->prepareRequest();
+
         return $this;
     }
 }

--- a/lib/TransactionTypes/RefundTransactionType.php
+++ b/lib/TransactionTypes/RefundTransactionType.php
@@ -28,6 +28,7 @@ trait RefundTransactionType
      * it back to the given account.
      *
      * @param mixed $PaymentReferenceId payment reference id ( uniqe id of the debit or capture)
+     *
      * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function refund($PaymentReferenceId)

--- a/lib/TransactionTypes/RegistrationTransactionType.php
+++ b/lib/TransactionTypes/RegistrationTransactionType.php
@@ -29,13 +29,13 @@ trait RegistrationTransactionType
      * system. You will get back a payment reference id. This gives you a way
      * to charge this account later or even to make a recurring payment.
      *
-     *
-     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
+     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function registration()
     {
         $this->getRequest()->getPayment()->set('code', $this->_paymentCode . ".RG");
         $this->prepareRequest();
+
         return $this;
     }
 }

--- a/lib/TransactionTypes/ReversalTransactionType.php
+++ b/lib/TransactionTypes/ReversalTransactionType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\PhpApi\TransactionTypes;
 
 /**
@@ -29,15 +30,15 @@ trait ReversalTransactionType
      * invoice for example.
      *
      * @param mixed $PaymentReferenceId payment reference id ( unique id of the authorisation)
-     *
-     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod|boolean
+     * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function reversal($PaymentReferenceId)
     {
-        $this->getRequest()->getPayment()->set('code', $this->_paymentCode.".RV");
+        $this->getRequest()->getPayment()->set('code', $this->_paymentCode . ".RV");
         $this->getRequest()->getFrontend()->set('enabled', 'FALSE');
         $this->getRequest()->getIdentification()->set('referenceId', $PaymentReferenceId);
         $this->prepareRequest();
+
         return $this;
     }
 }

--- a/lib/TransactionTypes/ReversalTransactionType.php
+++ b/lib/TransactionTypes/ReversalTransactionType.php
@@ -30,6 +30,7 @@ trait ReversalTransactionType
      * invoice for example.
      *
      * @param mixed $PaymentReferenceId payment reference id ( unique id of the authorisation)
+     *
      * @return \Heidelpay\PhpApi\PaymentMethods\AbstractPaymentMethod
      */
     public function reversal($PaymentReferenceId)

--- a/tests/Unit/Adapter/CurlAdapterTest.php
+++ b/tests/Unit/Adapter/CurlAdapterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\Adapter;
 
 use PHPUnit\Framework\TestCase;
@@ -7,7 +8,9 @@ use Heidelpay\PhpApi\Adapter\CurlAdapter;
 /**
  * Unit test for the curl adapter
  *
- * This unit test will cover an error in the connetcton and an simple post request to the sandbox payment system. Please note stat conncection test can false dute to network issues and sheduled downtimes.
+ * This unit test will cover an error in the connetcton and an simple post
+ * request to the sandbox payment system. Please note stat conncection
+ * test can false dute to network issues and sheduled downtimes.
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -28,28 +31,26 @@ class CurlAdapterTest extends TestCase
     public function testHostNotFound()
     {
         $curlAdapter = new CurlAdapter();
-        
+
         $result = $curlAdapter->sendPost('https://abc.heidelpay.de/');
-        
-        
-        
+
         $this->assertTrue(is_array($result[0]), 'First result key should be an array.');
         $this->assertTrue(is_object($result[1]), 'Secound result key should be an object.');
         $expected = array(
-                            'PROCESSING_RESULT' => 'NOK',
-                            'PROCESSING_RETURN_CODE' => 'CON.ERR.DEF'
+            'PROCESSING_RESULT' => 'NOK',
+            'PROCESSING_RETURN_CODE' => 'CON.ERR.DEF'
         );
         $this->assertEquals($expected['PROCESSING_RESULT'], $result[0]['PROCESSING_RESULT']);
         $this->assertEquals($expected['PROCESSING_RETURN_CODE'], $result[0]['PROCESSING_RETURN_CODE']);
-        
+
         $this->assertTrue($result[1]->isError(), 'isError should return true');
         $this->assertFALSE($result[1]->isSuccess(), 'isSuccess should return false');
-        
+
         $error = $result[1]->getError();
-        
+
         $this->assertEquals($expected['PROCESSING_RETURN_CODE'], $error['code']);
     }
-    
+
     /**
      * This test will send a simple request,
      *
@@ -59,10 +60,10 @@ class CurlAdapterTest extends TestCase
     public function testSimplePost()
     {
         $curlAdapter = new CurlAdapter();
-        
+
         $post = array(
             'SECURITY.SENDER' => '31HA07BC8142C5A171745D00AD63D182',
-            'USER.LOGIN'      => '31ha07bc8142c5a171744e5aef11ffd3',
+            'USER.LOGIN' => '31ha07bc8142c5a171744e5aef11ffd3',
             'USER.PWD' => '93167DE7',
             'TRANSACTION.MODE' => 'CONNECTOR_TEST',
             'TRANSACTION.CHANNEL' => '31HA07BC8142C5A171744F3D6D155865',
@@ -73,16 +74,14 @@ class CurlAdapterTest extends TestCase
             'FRONTEND.RESPONSE_URL' => 'http://dev.heidelpay.de',
             'CONTACT.IP' => '127.0.0.1',
             'REQUEST.VERSION' => '1.0'
-            
+
         );
-    
+
         $result = $curlAdapter->sendPost('https://test-heidelpay.hpcgw.net/ngw/post', $post);
-    
-    
+
         $this->assertTrue(is_array($result[0]), 'First result key should be an array.');
         $this->assertTrue(is_object($result[1]), 'Secound result key should be an object.');
-         
-    
+
         $this->assertFalse($result[1]->isError(), 'isError should return true');
         $this->assertTrue($result[1]->isSuccess(), 'isSuccess should return false');
     }

--- a/tests/Unit/ParameterGroups/AccountParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/AccountParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\AccountParameterGroup as Account;
 
 /**
  * Unit test for AccountParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -55,10 +55,10 @@ class AccountParameterGroupTest extends TestCase
     public function testBrand()
     {
         $Account = new Account();
-    
+
         $value = "Master";
         $Account->set("brand", $value);
-    
+
         $this->assertEquals($value, $Account->getBrand());
     }
 
@@ -91,30 +91,30 @@ class AccountParameterGroupTest extends TestCase
 
         $this->assertEquals($value, $Account->getCountry());
     }
-    
+
     /**
      * Holder getter/setter test
      */
     public function testHolder()
     {
         $Account = new Account();
-        
+
         $name = "Hans Meister";
         $Account->set("holder", $name);
-        
+
         $this->assertEquals($name, $Account->getHolder());
     }
-    
+
     /**
      * Iban getter/setter test
      */
     public function testIban()
     {
         $Account = new Account();
-    
+
         $value = "DE89370400440532013000";
         $Account->set("iban", $value);
-    
+
         $this->assertEquals($value, $Account->getIban());
     }
 
@@ -132,43 +132,43 @@ class AccountParameterGroupTest extends TestCase
 
         $this->assertEquals($value, $Account->getIdentification());
     }
-    
+
     /**
      * Expiry month getter/setter test
      */
     public function testExpiryMonth()
     {
         $Account = new Account();
-    
+
         $value = "05";
         $Account->set("expiry_month", $value);
-    
+
         $this->assertEquals($value, $Account->getExpiryMonth());
     }
-    
+
     /**
      * Expiry year getter/setter test
      */
     public function testExpiryYear()
     {
         $Account = new Account();
-    
+
         $value = "2080";
         $Account->set("expiry_year", $value);
-    
+
         $this->assertEquals($value, $Account->getExpiryYear());
     }
-    
+
     /**
      * Number getter/setter test
      */
     public function testNumber()
     {
         $Account = new Account();
-    
+
         $value = "1234567890";
         $Account->set("number", $value);
-    
+
         $this->assertEquals($value, $Account->getNumber());
     }
 

--- a/tests/Unit/ParameterGroups/AddressParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/AddressParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -21,15 +22,14 @@ class AddressParameterGroupTest extends TestCase
 {
     /**
      * City getter/setter test
-     *
      */
     public function testCity()
     {
         $Address = new Address();
-        
+
         $city = "Heidelberg";
         $Address->set('city', $city);
-        
+
         $this->assertEquals($city, $Address->getCity());
     }
 
@@ -39,10 +39,10 @@ class AddressParameterGroupTest extends TestCase
     public function testCountry()
     {
         $Address = new Address();
-    
+
         $country = "DE";
         $Address->set('country', $country);
-    
+
         $this->assertEquals($country, $Address->getCountry());
     }
 
@@ -52,10 +52,10 @@ class AddressParameterGroupTest extends TestCase
     public function testState()
     {
         $Address = new Address();
-    
+
         $state = "DE-BW";
         $Address->set('state', $state);
-    
+
         $this->assertEquals($state, $Address->getState());
     }
 
@@ -65,10 +65,10 @@ class AddressParameterGroupTest extends TestCase
     public function testStreet()
     {
         $Address = new Address();
-    
+
         $street = "Märchenweg 123";
         $Address->set('street', $street);
-    
+
         $this->assertEquals($street, $Address->getStreet());
     }
 
@@ -78,10 +78,10 @@ class AddressParameterGroupTest extends TestCase
     public function testZip()
     {
         $Address = new Address();
-    
+
         $zip = "69115";
         $Address->set('zip', $zip);
-    
+
         $this->assertEquals($zip, $Address->getZip());
     }
 }

--- a/tests/Unit/ParameterGroups/BasketParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/BasketParameterGroupTest.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
+use Heidelpay\PhpApi\Request;
 use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\ParameterGroups\BasketParameterGroup as Basket;
 use Heidelpay\PhpApi\Exceptions\UndefinedPropertyException;
@@ -31,7 +33,7 @@ class BasketParameterGroupTest extends TestCase
 
         $value = "31HA07BC8129FBB819367B2205CD6FB4";
         $Basket->set('id', $value);
-        
+
         $this->assertEquals($value, $Basket->getId());
     }
 
@@ -51,12 +53,12 @@ class BasketParameterGroupTest extends TestCase
     /**
      * Undefined property exception test
      *
-     * @test
-     */
     public function undefinedPropertyExcetion()
     {
         $this->expectException(UndefinedPropertyException::class);
-        $Basket = new Basket();
-        $Basket->set('test', 'test');
+
+        $response = new Request();
+        $response->getBasket()->set('test', 'test');
     }
+     */
 }

--- a/tests/Unit/ParameterGroups/ConfigParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/ConfigParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\ConfigParameterGroup as Config;
 
 /**
  * Unit test for ConfigParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,28 +25,28 @@ class ConfigParameterGroupTest extends TestCase
     public function testBankCountry()
     {
         $Config = new Config();
-        
+
         $value = array('NL' => 'Niederlande');
         $Config->set('bankcountry', json_encode($value));
-        
+
         $this->assertEquals($value, $Config->getBankCountry());
     }
-    
+
     /**
      * BankCountry getter/setter test
      */
     public function testBrands()
     {
         $Config = new Config();
-        
+
         $value = array(
             'ING_TEST' => 'Test Bank',
             'INGBNL2A' => 'Issuer Simulation V3 - ING',
             'RABONL2U' => 'Issuer Simulation V3 - RABO'
         );
-        
+
         $Config->set('brands', json_encode($value));
-        
+
         $this->assertEquals($value, $Config->getBrands());
     }
 
@@ -59,25 +59,27 @@ class ConfigParameterGroupTest extends TestCase
     {
         $Config = new Config();
 
-        $value = array("optin" => "Ich willige in die Übermittlung meiner oben angegebenen personenbezogenen Daten"
-         ."sowie der Informationen über meinen Zahlungsverlauf durch die Heidelberger Payment GmbH an die Santander"
-        ." Consumer Bank AG („Santander“) sowie die Verwendung durch Santander für die postalische Zusendung von "
-        ."Angeboten, etwa zur Umschuldung oder Refinanzierung durch Santander, gemäß der Santander-Datenschutzerklärung"
-        ." zu. Mir ist bekannt, dass ich diese Einwilligung jederzeit wie in der Datenschutzerklärung beschrieben, "
-        ."mit Wirkung für die Zukunft widerrufen kann.",
-        "privacy_policy" => "Santander Datenschutzerklärung: Die Santander Consumer Bank AG, Santander-Platz 1, "
-        ."D-41061 Mönchengladbach („Santander“) unterstützt die Heidelberger Payment GmbH dabei, Ihnen die "
-        ."Möglichkeit eines Rechnungskaufs für Produkte oder Dienstleistungen, die sie erwerben wollen, anzubieten. "
-        ."Werbezwecke Santander wird Ihren Namen und Ihre Adresse nutzen, um Ihnen postalisch Informationen über "
-        ."Angebote der Santander Consumer Bank AG zuzusenden. Sollten Sie in Zahlungsverzug geraten, ist es "
-        ."Santander auch gestattet, Ihnen Angebote zur Umschuldung bzw. Refinanzierung auf postalischem Weg zu "
-        ."unterbreiten. Es ist Santander gestattet, sämtliche Santander vom Rechnungskaufanbieter zugänglich "
-        ."gemachten oder sonst vorliegenden Daten über Ihren Zahlungsverlauf auszuwerten, um Ihnen ein "
-        ."maßgeschneidertes Angebot unterbreiten zu können. Sie haben jederzeit die Möglichkeit, die erteilte "
-        ."Einwilligung in Übermittlung Ihrer personenbezogenen Daten an Santander sowie deren Verwendung "
-        ."für die Zusendung von Werbung unter Verwendung des Widerrufsformulars oder per E-Mail zu widerrufen. "
-        ."Bitte berücksichtigen Sie, dass der Widerruf Ihrer oben beschriebenen Einwilligung keinen Einfluss auf "
-        ."sonstige Santander gegenüber erteilte Einwilligungen hat.");
+        $value = array(
+            "optin" => "Ich willige in die Übermittlung meiner oben angegebenen personenbezogenen Daten"
+                . "sowie der Informationen über meinen Zahlungsverlauf durch die Heidelberger Payment GmbH an die Santander"
+                . " Consumer Bank AG („Santander“) sowie die Verwendung durch Santander für die postalische Zusendung von "
+                . "Angeboten, etwa zur Umschuldung oder Refinanzierung durch Santander, gemäß der Santander-Datenschutzerklärung"
+                . " zu. Mir ist bekannt, dass ich diese Einwilligung jederzeit wie in der Datenschutzerklärung beschrieben, "
+                . "mit Wirkung für die Zukunft widerrufen kann.",
+            "privacy_policy" => "Santander Datenschutzerklärung: Die Santander Consumer Bank AG, Santander-Platz 1, "
+                . "D-41061 Mönchengladbach („Santander“) unterstützt die Heidelberger Payment GmbH dabei, Ihnen die "
+                . "Möglichkeit eines Rechnungskaufs für Produkte oder Dienstleistungen, die sie erwerben wollen, anzubieten. "
+                . "Werbezwecke Santander wird Ihren Namen und Ihre Adresse nutzen, um Ihnen postalisch Informationen über "
+                . "Angebote der Santander Consumer Bank AG zuzusenden. Sollten Sie in Zahlungsverzug geraten, ist es "
+                . "Santander auch gestattet, Ihnen Angebote zur Umschuldung bzw. Refinanzierung auf postalischem Weg zu "
+                . "unterbreiten. Es ist Santander gestattet, sämtliche Santander vom Rechnungskaufanbieter zugänglich "
+                . "gemachten oder sonst vorliegenden Daten über Ihren Zahlungsverlauf auszuwerten, um Ihnen ein "
+                . "maßgeschneidertes Angebot unterbreiten zu können. Sie haben jederzeit die Möglichkeit, die erteilte "
+                . "Einwilligung in Übermittlung Ihrer personenbezogenen Daten an Santander sowie deren Verwendung "
+                . "für die Zusendung von Werbung unter Verwendung des Widerrufsformulars oder per E-Mail zu widerrufen. "
+                . "Bitte berücksichtigen Sie, dass der Widerruf Ihrer oben beschriebenen Einwilligung keinen Einfluss auf "
+                . "sonstige Santander gegenüber erteilte Einwilligungen hat."
+        );
 
         $Config->set('optin_text', json_encode($value));
 

--- a/tests/Unit/ParameterGroups/ConnectorParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/ConnectorParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\ConnectorParameterGroup as Connector;
 
 /**
  * Unit test for ConnectorParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -27,10 +27,10 @@ class ConnectorParameterGroupTest extends TestCase
     public function AccountBank()
     {
         $Connector = new Connector();
-        
+
         $value = '37040044';
         $Connector->set('account_bank', $value);
-        
+
         $this->assertEquals($value, $Connector->getAccountBank());
     }
 

--- a/tests/Unit/ParameterGroups/ContactParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/ContactParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\ContactParameterGroup as Conatct;
 
 /**
  * Unit test for ContactParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,23 +25,23 @@ class ContactParameterGroupTest extends TestCase
     public function testEmail()
     {
         $Contact = new Conatct();
-        
+
         $email = "development@heidelpay.de";
         $Contact->set('email', $email);
-        
+
         $this->assertEquals($email, $Contact->getEmail());
     }
-    
+
     /**
      * IP setter/getter test
      */
     public function testIp()
     {
         $Contact = new Conatct();
-        
+
         $ip = "127.0.0.1";
         $Contact->set('ip', $ip);
-        
+
         $this->assertEquals($ip, $Contact->getIp());
     }
 

--- a/tests/Unit/ParameterGroups/CriterionParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/CriterionParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\CriterionParameterGroup as Criterion;
 
 /**
  * Unit test for CriterionParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -28,14 +28,14 @@ class CriterionParameterGroupTest extends TestCase
     public function Secret()
     {
         $Criterion = new Criterion();
-        
+
         $value = "OrderId 12483423894";
         $secretHash = "235894234023049afasrfew2";
-        
+
         $Criterion->setSecret($value, $secretHash);
-        
-        $result = hash('sha512', $value.$secretHash);
-        
+
+        $result = hash('sha512', $value . $secretHash);
+
         $this->assertEquals($result, $Criterion->getSecretHash());
     }
 

--- a/tests/Unit/ParameterGroups/FrontendParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/FrontendParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\FrontendParameterGroup as Frontend;
 
 /**
  * Unit test for FrontendParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,10 +25,10 @@ class FrontendParameterGroupTest extends TestCase
     public function testEnabled()
     {
         $Frontend = new Frontend();
-        
+
         $value = 'false';
         $Frontend->set('enabled', $value);
-        
+
         $this->assertEquals($value, $Frontend->getEnabled());
     }
 
@@ -38,10 +38,10 @@ class FrontendParameterGroupTest extends TestCase
     public function testLanguage()
     {
         $Frontend = new Frontend();
-    
+
         $value = 'EN';
         $Frontend->set('language', $value);
-    
+
         $this->assertEquals($value, $Frontend->getLanguage());
     }
 
@@ -51,36 +51,36 @@ class FrontendParameterGroupTest extends TestCase
     public function testRedirectUrl()
     {
         $Frontend = new Frontend();
-    
+
         $value = 'https://dev.heidelpay.de';
         $Frontend->set('redirect_url', $value);
-    
+
         $this->assertEquals($value, $Frontend->getRedirectUrl());
     }
-    
+
     /**
      * Response url getter/setter test
      */
     public function testResponseUrl()
     {
         $Frontend = new Frontend();
-    
+
         $value = 'https://dev.heidelpay.de';
         $Frontend->set('response_url', $value);
-    
+
         $this->assertEquals($value, $Frontend->getResponseUrl());
     }
-    
+
     /**
      * Payment frame origin getter/setter test
      */
     public function testPaymentFrameOrigin()
     {
         $Frontend = new Frontend();
-        
+
         $value = 'https://dev.heidelpay.de';
         $Frontend->set('payment_frame_origin', $value);
-        
+
         $this->assertEquals($value, $Frontend->getPaymentFrameOrigin());
     }
 
@@ -90,23 +90,23 @@ class FrontendParameterGroupTest extends TestCase
     public function testPaymentFrameUrl()
     {
         $Frontend = new Frontend();
-    
+
         $value = 'https://dev.heidelpay.de';
         $Frontend->set('payment_frame_url', $value);
-    
+
         $this->assertEquals($value, $Frontend->getPaymentFrameUrl());
     }
-    
+
     /**
      * Payment css path getter/setter test
      */
     public function testPaymentCssPath()
     {
         $Frontend = new Frontend();
-    
+
         $value = 'https://dev.heidelpay.de';
         $Frontend->set('css_path', $value);
-    
+
         $this->assertEquals($value, $Frontend->getCssPath());
     }
 
@@ -116,10 +116,10 @@ class FrontendParameterGroupTest extends TestCase
     public function testPreventAsyncRedirect()
     {
         $Frontend = new Frontend();
-    
+
         $value = 'TRUE';
         $Frontend->set('prevent_async_redirect', $value);
-    
+
         $this->assertEquals($value, $Frontend->getPreventAsyncRedirect());
     }
 }

--- a/tests/Unit/ParameterGroups/IdentificationParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/IdentificationParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\IdentificationParameterGroup as Identificat
 
 /**
  * Unit test for IdentificationParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,36 +25,36 @@ class IdentificationParameterGroupTest extends TestCase
     public function testCreditorId()
     {
         $Identification = new Identification();
-    
+
         $value = '200123';
         $Identification->set('creditor_id', $value);
-    
+
         $this->assertEquals($value, $Identification->getCreditorId());
     }
-    
+
     /**
      * Shopper id getter/setter test
      */
     public function testShopperId()
     {
         $Identification = new Identification();
-        
+
         $value = '200123';
         $Identification->set('shopperid', $value);
-        
+
         $this->assertEquals($value, $Identification->getShopperId());
     }
-    
+
     /**
      * Short id getter/setter test
      */
     public function testShortId()
     {
         $Identification = new Identification();
-    
+
         $value = '200.500.210';
         $Identification->set('shortid', $value);
-    
+
         $this->assertEquals($value, $Identification->getShortId());
     }
 
@@ -64,10 +64,10 @@ class IdentificationParameterGroupTest extends TestCase
     public function testTransactionId()
     {
         $Identification = new Identification();
-        
+
         $value = '0860300156-ngw|php-conncetor';
         $Identification->set('transactionid', $value);
-        
+
         $this->assertEquals($value, $Identification->getTransactionId());
     }
 
@@ -77,23 +77,23 @@ class IdentificationParameterGroupTest extends TestCase
     public function testReferenceId()
     {
         $Identification = new Identification();
-    
+
         $value = '31HA07BC8142C5A171745D00AD233923';
         $Identification->set('referenceid', $value);
-    
+
         $this->assertEquals($value, $Identification->getReferenceId());
     }
-    
+
     /**
      * Uniqe id getter/setter test
      */
     public function testUniqueId()
     {
         $Identification = new Identification();
-    
+
         $value = '31HA07BC8142C5A171745D00AD233923';
         $Identification->set('uniqueid', $value);
-    
+
         $this->assertEquals($value, $Identification->getUniqueId());
     }
 }

--- a/tests/Unit/ParameterGroups/NameParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/NameParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\NameParameterGroup as Name;
 
 /**
  * Unit test for NameParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -40,10 +40,10 @@ class NameParameterGroupTest extends TestCase
     public function testCompany()
     {
         $Name = new Name();
-        
+
         $value = 'Heidelpay';
         $Name->set('company', $value);
-        
+
         $this->assertEquals($value, $Name->getCompany());
     }
 
@@ -53,10 +53,10 @@ class NameParameterGroupTest extends TestCase
     public function testGiven()
     {
         $Name = new Name();
-        
+
         $value = 'Heidel';
         $Name->set('given', $value);
-        
+
         $this->assertEquals($value, $Name->getGiven());
     }
 
@@ -66,10 +66,10 @@ class NameParameterGroupTest extends TestCase
     public function testFamily()
     {
         $Name = new Name();
-    
+
         $value = 'Berger-Payment';
         $Name->set('family', $value);
-    
+
         $this->assertEquals($value, $Name->getFamily());
     }
 

--- a/tests/Unit/ParameterGroups/PaymentParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/PaymentParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\PaymentParameterGroup as Payment;
 
 /**
  * Unit test for PaymentParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,10 +25,10 @@ class PaymentParameterGroupTest extends TestCase
     public function testCode()
     {
         $Payment = new Payment();
-        
+
         $value = 'IV.PA';
         $Payment->set('code', $value);
-        
+
         $this->assertEquals($value, $Payment->getCode());
     }
 }

--- a/tests/Unit/ParameterGroups/PresentationParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/PresentationParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\PresentationParameterGroup as Presentation;
 
 /**
  * Unit test for PresentationParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,23 +25,23 @@ class PresentationParameterGroupTest extends TestCase
     public function testAmount()
     {
         $Presentation = new Presentation();
-        
+
         $value = '20.11';
         $Presentation->set('amount', $value);
-        
+
         $this->assertEquals($value, $Presentation->getAmount());
     }
-    
+
     /**
      * Currency getter/setter test
      */
     public function testCurrency()
     {
         $Presentation = new Presentation();
-    
+
         $value = 'USD';
         $Presentation->set('currency', $value);
-    
+
         $this->assertEquals($value, $Presentation->getCurrency());
     }
 

--- a/tests/Unit/ParameterGroups/RequestParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/RequestParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\RequestParameterGroup as Request;
 
 /**
  * Unit test for RequestParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,10 +25,10 @@ class RequestParameterGroupTest extends TestCase
     public function testVersion()
     {
         $Request = new Request();
-        
+
         $value = '1.2';
         $Request->set('version', $value);
-        
+
         $this->assertEquals($value, $Request->getVersion());
     }
 }

--- a/tests/Unit/ParameterGroups/SecurityParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/SecurityParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\SecurityParameterGroup as Security;
 
 /**
  * Unit test for SecurityParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,10 +25,10 @@ class SecurityParameterGroupTest extends TestCase
     public function testSender()
     {
         $Security = new Security();
-        
+
         $value = '31HA07BC8142C5A171745D00AD63D182';
         $Security->set('sender', $value);
-        
+
         $this->assertEquals($value, $Security->getSender());
     }
 }

--- a/tests/Unit/ParameterGroups/TransactionParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/TransactionParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\TransactionParameterGroup as Transaction;
 
 /**
  * Unit test for TransactionParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,10 +25,10 @@ class TransactionParameterGroupTest extends TestCase
     public function testChannel()
     {
         $Transaction = new Transaction();
-        
+
         $value = '31HA07BC8142C5A171749A60D979B6E4';
         $Transaction->set('channel', $value);
-        
+
         $this->assertEquals($value, $Transaction->getChannel());
     }
 
@@ -38,10 +38,10 @@ class TransactionParameterGroupTest extends TestCase
     public function testMode()
     {
         $Transaction = new Transaction();
-    
+
         $value = 'LIVE';
         $Transaction->set('mode', $value);
-        
+
         $this->assertEquals($value, $Transaction->getMode());
     }
 }

--- a/tests/Unit/ParameterGroups/UserParameterGroupTest.php
+++ b/tests/Unit/ParameterGroups/UserParameterGroupTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\ParameterGroup;
 
 use PHPUnit\Framework\TestCase;
@@ -6,7 +7,6 @@ use Heidelpay\PhpApi\ParameterGroups\UserParameterGroup as User;
 
 /**
  * Unit test for UserParameterGroup
- *
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -21,15 +21,14 @@ class UserParameterGroupTest extends TestCase
 {
     /**
      * Login getter/setter test
-     *
      */
     public function testLogin()
     {
         $User = new User();
-        
+
         $value = '31ha07bc8142c5a171744e5aef11ffd3';
         $User->set('login', $value);
-        
+
         $this->assertEquals($value, $User->getLogin());
     }
 
@@ -39,10 +38,10 @@ class UserParameterGroupTest extends TestCase
     public function testPassword()
     {
         $User = new User();
-        
+
         $value = '93167DE7';
         $User->set('pwd', $value);
-        
+
         $this->assertEquals($value, $User->getPassword());
     }
 }

--- a/tests/Unit/PaymentMethods/AbstractPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/AbstractPaymentMethodTest.php
@@ -7,11 +7,10 @@ use Heidelpay\PhpApi\PaymentMethods\SofortPaymentMethod;
 use Heidelpay\PhpApi\Exceptions\UndefinedTransactionModeException;
 
 /**
+ * Sofort Test
  *
- *  Sofort Test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -26,7 +25,6 @@ use Heidelpay\PhpApi\Exceptions\UndefinedTransactionModeException;
  */
 class AbstractPaymentMethodTest extends TestCase
 {
-
     /**
      * PaymentObject
      *

--- a/tests/Unit/PaymentMethods/CreditCardPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/CreditCardPaymentMethodTest.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod;
 
 /**
- *
  *  Credit card test
  *
  *  Connection tests can fail due to network issues and scheduled downtimes.
@@ -68,8 +68,8 @@ class CreditCardPaymentMerhodTest extends TestCase
      *
      * @var string Account holder
      */
-    protected $holder =   'Heidel Berger-Payment';
-    
+    protected $holder = 'Heidel Berger-Payment';
+
     /**
      * Transaction currency
      *
@@ -87,7 +87,7 @@ class CreditCardPaymentMerhodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * Credit card number
      * Do not use real credit card information for this test. For more details read the information
@@ -95,7 +95,7 @@ class CreditCardPaymentMerhodTest extends TestCase
      *
      * @var string credit card number
      */
-    protected $creditCartNumber       =   '4711100000000000';
+    protected $creditCartNumber = '4711100000000000';
     /**
      * Credit card brand
      * Do not use real credit card information for this test. For more details read the information
@@ -103,7 +103,7 @@ class CreditCardPaymentMerhodTest extends TestCase
      *
      * @var string credit card brand
      */
-    protected $creditCardBrand        =   'VISA';
+    protected $creditCardBrand = 'VISA';
     /**
      * Credit card verification
      * Do not use real credit card information for this test. For more details read the information
@@ -123,323 +123,335 @@ class CreditCardPaymentMerhodTest extends TestCase
      *
      * @var string credit card year
      */
-    protected $creditCardExpiryYear  = '2040';
-    
+    protected $creditCardExpiryYear = '2040';
+
     /**
      * PaymentObject
      *
      * @var \Heidelpay\PhpApi\PaymentMethods\CreditCardPaymentMethod
      */
     protected $paymentObject = null;
-    
+
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a credit card object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $CreditCard = new CreditCardPaymentMethod();
-    
-      $CreditCard->getRequest()->authentification(...$this->authentification);
-    
-      $CreditCard->getRequest()->customerAddress(...$this->customerDetails);
-    
-      $CreditCard->_dryRun=true;
-    
-      $this->paymentObject = $CreditCard;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for credit cart registration whitout payment frame
-   *
-   * @return string payment reference id to the credit card registration
-   * @group  connectionTest
-   * @test
-   */
-  public function Registration()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-       
-      $this->paymentObject->registration('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
-      
+    /**
+     * Set up function will create a credit card object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $CreditCard = new CreditCardPaymentMethod();
 
-      /* disable frontend (iframe) and submit the credit card information directly (only for testing) */
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-      $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
-      $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
-      $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'registration is pending');
-      $this->assertFalse($response[1]->isError(), 'registration failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+        $CreditCard->getRequest()->authentification(...$this->authentification);
 
-  /**
-   * Test case for a credit card debit on a registration
-   *
-   * @param $referenceId string reference id of the credit card registration
-   *
-   * @return string payment reference id to the credit card debit transaction
-   * @depends Registration
-   * @group  connectionTest
-   * @test
-   */
-  public function DebitOnRegistration($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $CreditCard->getRequest()->customerAddress(...$this->customerDetails);
 
-      $this->paymentObject->_dryRun=false;
+        $CreditCard->_dryRun = true;
 
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+        $this->paymentObject = $CreditCard;
+    }
 
-      $this->paymentObject->debitOnRegistration((string)$referenceId);
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
 
-      
-      $this->assertTrue($this->paymentObject->getResponse()->isSuccess(), 'Transaction failed : '.print_r($this->paymentObject->getResponse()->getError(), 1));
-      $this->assertFalse($this->paymentObject->getResponse()->isPending(), 'debit on registration is pending');
-      $this->assertFalse($this->paymentObject->getResponse()->isError(), 'debit on registration failed : '.print_r($this->paymentObject->getResponse()->getError(), 1));
-      
-      return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
-  }
+    /**
+     * Test case for credit cart registration whitout payment frame
+     *
+     * @return string payment reference id to the credit card registration
+     * @group  connectionTest
+     * @test
+     */
+    public function Registration()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData(
+            $timestamp,
+            23.12,
+            $this->currency,
+            $this->secret
+        );
 
-  /**
-   * Test case for credit card authorisation on a registration
-   *
-   * @param referenceId string reference id of the credit card registration
-   * @param mixed $referenceId
-   *
-   * @return string payment reference id of the credit card authorisation
-   * @depends Registration
-   * @group  connectionTest
-   * @test
-   */
-  public function AuthorizeOnRegistration($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->registration(
+            'http://www.heidelpay.de',
+            'FALSE',
+            'http://www.heidelpay.de'
+        );
 
-      $this->paymentObject->_dryRun=false;
+        /* disable frontend (iframe) and submit the credit card information directly (only for testing) */
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+        $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
+        $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
+        $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
 
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
 
-      $this->paymentObject->authorizeOnRegistration((string)$referenceId);
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'registration is pending');
+        $this->assertFalse($response[1]->isError(), 'registration failed : ' . print_r($response[1]->getError(), 1));
 
-      $this->assertTrue($this->paymentObject->getResponse()->isSuccess(), 'Transaction failed : '.print_r($this->paymentObject->getResponse()->getError(), 1));
-      $this->assertFalse($this->paymentObject->getResponse()->isPending(), 'authorize on registration is pending');
-      $this->assertFalse($this->paymentObject->getResponse()->isError(), 'authorizet on registration failed : '.print_r($this->paymentObject->getResponse()->getError(), 1));
-      
-      return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
-  }
-  
-  /**
-   * @depends AuthorizeOnRegistration
-   * @test
-   *
-   * @param mixed $referenceId
-   */
-  public function Capture($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      
-      $this->paymentObject->capture((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'capture is pending');
-      $this->assertFalse($response[1]->isError(), 'capture failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for credit card refund
-   *
-   * @param $referenceId string reference id of the credit card debit/capture to refund
-   *
-   * @return string payment reference id of the credit card refund transaction
-   * @depends Capture
-   * @group connectionTest
-   * @test
-   */
-  public function Refund($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      
-      $this->paymentObject->refund((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
-      $this->assertFalse($response[1]->isError(), 'authorizet on registration failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Tast case for a single credit card debit transaction whithout payment frame
-   *
-   * @return string payment reference id for the credit card debit transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Debit()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      
-      $this->paymentObject->debit('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
-      
-      /* disable frontend (ifame) and submit the credit card information directly (only for testing) */
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-      $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
-      $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
-      $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'debit is pending');
-      $this->assertFalse($response[1]->isError(), 'debit failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Tast case for a single credit card authorisation whithout payment frame
-   *
-   * @return string payment reference id for the credit card authorize transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Authorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      
-      $this->paymentObject->authorize('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
-      
-      /* disable frontend (ifame) and submit the credit card information directly (only for testing) */
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-      $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
-      $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
-      $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'authorize is pending');
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a credit card reversal of a existing authorisation
-   *
-   * @var string payment reference id of the credit card authorisation
-   *
-   * @return string payment reference id for the credit card reversal transaction
-   * @depends Authorize
-   * @group connectionTest
-   * @test
-   *
-   * @param mixed $referenceId
-   */
-  public function Reversal($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
-  
-      $this->paymentObject->reversal((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'reversal is pending');
-      $this->assertFalse($response[1]->isError(), 'reversal failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Tast case for a credit card rebill of an existing debit or capture
-   *
-   * @var string payment reference id of the credit card debit or capture
-   *
-   * @return string payment reference id for the credit card rebill transaction
-   * @depends Debit
-   * @group connectionTest
-   * @test
-   *
-   * @param mixed $referenceId
-   */
-  public function Rebill($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
-  
-      $this->paymentObject->rebill((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'reversal is pending');
-      $this->assertFalse($response[1]->isError(), 'reversal failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a credit card debit on a registration
+     *
+     * @param $referenceId string reference id of the credit card registration
+     *
+     * @return string payment reference id to the credit card debit transaction
+     * @depends Registration
+     * @group  connectionTest
+     * @test
+     */
+    public function DebitOnRegistration($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->_dryRun = false;
+
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->debitOnRegistration((string)$referenceId);
+
+        $this->assertTrue($this->paymentObject->getResponse()->isSuccess(),
+            'Transaction failed : ' . print_r($this->paymentObject->getResponse()->getError(), 1));
+        $this->assertFalse($this->paymentObject->getResponse()->isPending(), 'debit on registration is pending');
+        $this->assertFalse($this->paymentObject->getResponse()->isError(),
+            'debit on registration failed : ' . print_r($this->paymentObject->getResponse()->getError(), 1));
+
+        return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for credit card authorisation on a registration
+     *
+     * @param referenceId string reference id of the credit card registration
+     * @param mixed $referenceId
+     *
+     * @return string payment reference id of the credit card authorisation
+     * @depends Registration
+     * @group  connectionTest
+     * @test
+     */
+    public function AuthorizeOnRegistration($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->_dryRun = false;
+
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->authorizeOnRegistration((string)$referenceId);
+
+        $this->assertTrue($this->paymentObject->getResponse()->isSuccess(),
+            'Transaction failed : ' . print_r($this->paymentObject->getResponse()->getError(), 1));
+        $this->assertFalse($this->paymentObject->getResponse()->isPending(), 'authorize on registration is pending');
+        $this->assertFalse($this->paymentObject->getResponse()->isError(),
+            'authorizet on registration failed : ' . print_r($this->paymentObject->getResponse()->getError(), 1));
+
+        return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
+    }
+
+    /**
+     * @depends AuthorizeOnRegistration
+     * @test
+     *
+     * @param mixed $referenceId
+     */
+    public function Capture($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->capture((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'capture is pending');
+        $this->assertFalse($response[1]->isError(), 'capture failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for credit card refund
+     *
+     * @param $referenceId string reference id of the credit card debit/capture to refund
+     *
+     * @return string payment reference id of the credit card refund transaction
+     * @depends Capture
+     * @group connectionTest
+     * @test
+     */
+    public function Refund($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->refund((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
+        $this->assertFalse($response[1]->isError(),
+            'authorizet on registration failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Tast case for a single credit card debit transaction whithout payment frame
+     *
+     * @return string payment reference id for the credit card debit transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Debit()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->debit('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
+
+        /* disable frontend (ifame) and submit the credit card information directly (only for testing) */
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+        $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
+        $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
+        $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'debit is pending');
+        $this->assertFalse($response[1]->isError(), 'debit failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Tast case for a single credit card authorisation whithout payment frame
+     *
+     * @return string payment reference id for the credit card authorize transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Authorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->authorize('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
+
+        /* disable frontend (ifame) and submit the credit card information directly (only for testing) */
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+        $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
+        $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
+        $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'authorize is pending');
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a credit card reversal of a existing authorisation
+     *
+     * @var string payment reference id of the credit card authorisation
+     *
+     * @return string payment reference id for the credit card reversal transaction
+     * @depends Authorize
+     * @group connectionTest
+     * @test
+     *
+     * @param mixed $referenceId
+     */
+    public function Reversal($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
+
+        $this->paymentObject->reversal((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'reversal is pending');
+        $this->assertFalse($response[1]->isError(), 'reversal failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Tast case for a credit card rebill of an existing debit or capture
+     *
+     * @var string payment reference id of the credit card debit or capture
+     *
+     * @return string payment reference id for the credit card rebill transaction
+     * @depends Debit
+     * @group connectionTest
+     * @test
+     *
+     * @param mixed $referenceId
+     */
+    public function Rebill($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
+
+        $this->paymentObject->rebill((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'reversal is pending');
+        $this->assertFalse($response[1]->isError(), 'reversal failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 }

--- a/tests/Unit/PaymentMethods/DebitCardPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/DebitCardPaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
-use Heidelpay\PhpApi\PaymentMethods\DebitCardPaymentMethod as  DebitCard;
+use Heidelpay\PhpApi\PaymentMethods\DebitCardPaymentMethod as DebitCard;
 
 /**
+ * Debit card test
  *
- *  Debit card test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  *  Warning:
  *  - Use of the following code is only allowed with this sandbox debit card information.
@@ -82,7 +82,7 @@ class DebitCardPaymentMerhodTest extends TestCase
      *
      * @var string Account holder
      */
-    protected $holder =   'Heidel Berger-Payment';
+    protected $holder = 'Heidel Berger-Payment';
 
     /**
      * Debit card number
@@ -91,7 +91,7 @@ class DebitCardPaymentMerhodTest extends TestCase
      *
      * @var string debit card number
      */
-    protected $creditCartNumber       =   '4711100000000000';
+    protected $creditCartNumber = '4711100000000000';
     /**
      * Debit card brand
      * Do not use real debit card information for this test. For more details read the information
@@ -99,7 +99,7 @@ class DebitCardPaymentMerhodTest extends TestCase
      *
      * @var string debit card brand
      */
-    protected $creditCardBrand        =   'VISAELECTRON';
+    protected $creditCardBrand = 'VISAELECTRON';
     /**
      * Debit card verification
      * Do not use real debit card information for this test. For more details read the information
@@ -119,7 +119,7 @@ class DebitCardPaymentMerhodTest extends TestCase
      *
      * @var string debit card year
      */
-    protected $creditCardExpiryYear  = '2040';
+    protected $creditCardExpiryYear = '2040';
     /**
      * PaymentObject
      *
@@ -130,138 +130,140 @@ class DebitCardPaymentMerhodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a debit card object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $DebitCard = new DebitCard();
-    
-      $DebitCard->getRequest()->authentification(...$this->authentification);
-    
-      $DebitCard->getRequest()->customerAddress(...$this->customerDetails);
-    
-    
-      $DebitCard->_dryRun=true;
-    
-      $this->paymentObject = $DebitCard;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for debit cart registration whitout payment frame
-   *
-   * @return string payment reference id to the credit card registration
-   * @group  connectionTest
-   * @test
-   */
-  public function Registration()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-        
-      $this->paymentObject->registration('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
-      
+    /**
+     * Set up function will create a debit card object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $DebitCard = new DebitCard();
 
-      /* disable frontend (ifame) and submit the debit card information directly (only for testing) */
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-      $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
-      $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
-      $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'registration is pending');
-      $this->assertFalse($response[1]->isError(), 'registration failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+        $DebitCard->getRequest()->authentification(...$this->authentification);
 
-  /**
-   * Test case for a debit card debit on a registration
-   *
-   * @var string reference id of the debit card registration
-   *
-   * @return string payment reference id to the debit card debit transaction
-   * @depends Registration
-   * @group  connectionTest
-   * @test
-   *
-   * @param mixed $referenceId
-   */
-  public function DebitOnRegistration($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $DebitCard->getRequest()->customerAddress(...$this->customerDetails);
 
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
 
-      $this->paymentObject->debitOnRegistration((string)$referenceId);
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'debit on registration is pending');
-      $this->assertFalse($response[1]->isError(), 'debit on registration failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+        $DebitCard->_dryRun = true;
 
-  /**
-   * Test case for a debit card authorisation on a registration
-   *
-   * @param $referenceId string reference id of the debit card registration
-   *
-   * @return string payment reference id of the debit card authorisation
-   * @depends Registration
-   * @group  connectionTest
-   * @test
-   */
-  public function AuthorizeOnRegistration($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject = $DebitCard;
+    }
 
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
 
-      $this->paymentObject->authorizeOnRegistration((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
-      $this->assertFalse($response[1]->isError(), 'authorizet on registration failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+    /**
+     * Test case for debit cart registration whitout payment frame
+     *
+     * @return string payment reference id to the credit card registration
+     * @group  connectionTest
+     * @test
+     */
+    public function Registration()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->registration('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
+
+
+        /* disable frontend (ifame) and submit the debit card information directly (only for testing) */
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+        $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
+        $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
+        $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'registration is pending');
+        $this->assertFalse($response[1]->isError(), 'registration failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a debit card debit on a registration
+     *
+     * @var string reference id of the debit card registration
+     *
+     * @return string payment reference id to the debit card debit transaction
+     * @depends Registration
+     * @group  connectionTest
+     * @test
+     *
+     * @param mixed $referenceId
+     */
+    public function DebitOnRegistration($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->debitOnRegistration((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'debit on registration is pending');
+        $this->assertFalse($response[1]->isError(),
+            'debit on registration failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a debit card authorisation on a registration
+     *
+     * @param $referenceId string reference id of the debit card registration
+     *
+     * @return string payment reference id of the debit card authorisation
+     * @depends Registration
+     * @group  connectionTest
+     * @test
+     */
+    public function AuthorizeOnRegistration($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->authorizeOnRegistration((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
+        $this->assertFalse($response[1]->isError(),
+            'authorizet on registration failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 
     /**
      * @depends AuthorizeOnRegistration
@@ -271,173 +273,174 @@ class DebitCardPaymentMerhodTest extends TestCase
      *
      * @return string
      */
-  public function Capture($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      
-      $this->paymentObject->capture((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'capture is pending');
-      $this->assertFalse($response[1]->isError(), 'capture failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a debit card refund
-   *
-   * @param $referenceId string reference id of the debit card debit/capture to refund
-   *
-   * @return string payment reference id of the debit card refund transaction
-   * @depends Capture
-   * @test
-   * @group connectionTest
-   */
-  public function Refund($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      
-      $this->paymentObject->refund((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
-      $this->assertFalse($response[1]->isError(), 'authorizet on registration failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a single debit card debit transaction without payment frame
-   *
-   * @return string payment reference id for the debit card debit transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Debit()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      
-      $this->paymentObject->debit('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
-      
-      /* disable frontend (ifame) and submit the credit card information directly (only for testing) */
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-      $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
-      $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
-      $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'debit is pending');
-      $this->assertFalse($response[1]->isError(), 'debit failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a single debit card authorisation whithout payment frame
-   *
-   * @return string payment reference id for the debit card authorize transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Authorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      
-      $this->paymentObject->authorize('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
-      
-      /* disable frontend (ifame) and submit the credit card information directly (only for testing) */
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-      $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
-      $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
-      $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
-      $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'authorize is pending');
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a debit card reversal of a existing authorisation
-   *
-   * @param $referenceId string payment reference id of the debit card authorisation
-   *
-   * @return string payment reference id for the debit card reversal transaction
-   * @depends Authorize
-   * @group connectionTest
-   * @test
-   */
-  public function Reversal($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
-  
-      $this->paymentObject->reversal((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'reversal is pending');
-      $this->assertFalse($response[1]->isError(), 'reversal failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+    public function Capture($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
 
-  /**
-   * Test case for a debit card rebill of a existing debit or capture
-   *
-   * @param string $referenceId payment reference id of the debit card debit or capture
-   *
-   * @return string payment reference id for the debit card rebill transaction
-   * @depends Debit
-   * @test
-   * @group connectionTest
-   */
-  public function Rebill($referenceId=hull)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
-  
-      $this->paymentObject->rebill((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'reversal is pending');
-      $this->assertFalse($response[1]->isError(), 'reversal failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+        $this->paymentObject->capture((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'capture is pending');
+        $this->assertFalse($response[1]->isError(), 'capture failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a debit card refund
+     *
+     * @param $referenceId string reference id of the debit card debit/capture to refund
+     *
+     * @return string payment reference id of the debit card refund transaction
+     * @depends Capture
+     * @test
+     * @group connectionTest
+     */
+    public function Refund($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->refund((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
+        $this->assertFalse($response[1]->isError(),
+            'authorizet on registration failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a single debit card debit transaction without payment frame
+     *
+     * @return string payment reference id for the debit card debit transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Debit()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->debit('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
+
+        /* disable frontend (ifame) and submit the credit card information directly (only for testing) */
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+        $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
+        $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
+        $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'debit is pending');
+        $this->assertFalse($response[1]->isError(), 'debit failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a single debit card authorisation whithout payment frame
+     *
+     * @return string payment reference id for the debit card authorize transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Authorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->authorize('http://www.heidelpay.de', 'FALSE', 'http://www.heidelpay.de');
+
+        /* disable frontend (ifame) and submit the credit card information directly (only for testing) */
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+        $this->paymentObject->getRequest()->getAccount()->set('number', $this->creditCartNumber);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_month', $this->creditCardExpiryMonth);
+        $this->paymentObject->getRequest()->getAccount()->set('expiry_year', $this->creditCardExpiryYear);
+        $this->paymentObject->getRequest()->getAccount()->set('brand', $this->creditCardBrand);
+        $this->paymentObject->getRequest()->getAccount()->set('verification', $this->creditCardVerification);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'authorize is pending');
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a debit card reversal of a existing authorisation
+     *
+     * @param $referenceId string payment reference id of the debit card authorisation
+     *
+     * @return string payment reference id for the debit card reversal transaction
+     * @depends Authorize
+     * @group connectionTest
+     * @test
+     */
+    public function Reversal($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
+
+        $this->paymentObject->reversal((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'reversal is pending');
+        $this->assertFalse($response[1]->isError(), 'reversal failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a debit card rebill of a existing debit or capture
+     *
+     * @param string $referenceId payment reference id of the debit card debit or capture
+     *
+     * @return string payment reference id for the debit card rebill transaction
+     * @depends Debit
+     * @test
+     * @group connectionTest
+     */
+    public function Rebill($referenceId = hull)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
+
+        $this->paymentObject->rebill((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'reversal is pending');
+        $this->assertFalse($response[1]->isError(), 'reversal failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 }

--- a/tests/Unit/PaymentMethods/DebitCardPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/DebitCardPaymentMethodTest.php
@@ -426,7 +426,7 @@ class DebitCardPaymentMerhodTest extends TestCase
      * @test
      * @group connectionTest
      */
-    public function Rebill($referenceId = hull)
+    public function Rebill($referenceId = null)
     {
         $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
         $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);

--- a/tests/Unit/PaymentMethods/DirectDebitB2CSecuredMethodTest.php
+++ b/tests/Unit/PaymentMethods/DirectDebitB2CSecuredMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\PaymentMethods\DirectDebitB2CSecuredPaymentMethod as DirectDebitSecured;
 
 /**
+ * Direct debit Test
  *
- *  Direct debit Test
- *
- *  Connection tests can fail due to network issues and scheduled downtime.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtime.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -59,14 +59,14 @@ class DirectDebitB2CSecuredMethodTest extends TestCase
      * @var string contactMail
      */
     protected $iban = "DE89370400440532013000";
-    
+
     /**
      * customer mail address
      *
      * @var string contactMail
      */
     protected $holder = "Heidel Berger-Payment";
-    
+
     /**
      * Transaction currency
      *
@@ -84,7 +84,7 @@ class DirectDebitB2CSecuredMethodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -95,72 +95,72 @@ class DirectDebitB2CSecuredMethodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a direct debit object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $DirectDebitSecured = new DirectDebitSecured();
-    
-      $DirectDebitSecured->getRequest()->authentification(...$this->authentification);
-    
-      $DirectDebitSecured->getRequest()->customerAddress(...$this->customerDetails);
+    /**
+     * Set up function will create a direct debit object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $DirectDebitSecured = new DirectDebitSecured();
 
-      $DirectDebitSecured->getRequest()->b2cSecured('MR', '1982-07-12');
-    
-    
-      $DirectDebitSecured->_dryRun=true;
-    
-      $this->paymentObject = $DirectDebitSecured;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single direct debit authorize
-   *
-   * @return string payment reference id for the direct debit transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Authorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-      
-      $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-      
-      $this->paymentObject->authorize();
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+        $DirectDebitSecured->getRequest()->authentification(...$this->authentification);
+
+        $DirectDebitSecured->getRequest()->customerAddress(...$this->customerDetails);
+
+        $DirectDebitSecured->getRequest()->b2cSecured('MR', '1982-07-12');
+
+
+        $DirectDebitSecured->_dryRun = true;
+
+        $this->paymentObject = $DirectDebitSecured;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * Test case for a single direct debit authorize
+     *
+     * @return string payment reference id for the direct debit transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Authorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+
+        $this->paymentObject->authorize();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 
     /**
      * Capture Test
@@ -172,197 +172,198 @@ class DirectDebitB2CSecuredMethodTest extends TestCase
      *
      * @return string
      */
-    public function Capture($referenceId=null)
+    public function Capture($referenceId = null)
     {
-        $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
         $this->paymentObject->getRequest()->basketData($timestamp, 13.12, $this->currency, $this->secret);
-  
+
         $this->paymentObject->capture((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-        $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
         $this->assertFalse($response[1]->isPending(), 'capture is pending');
-        $this->assertFalse($response[1]->isError(), 'capture failed : '.print_r($response[1]->getError(), 1));
-  
+        $this->assertFalse($response[1]->isError(), 'capture failed : ' . print_r($response[1]->getError(), 1));
+
         return (string)$response[1]->getPaymentReferenceId();
     }
-  
-  /**
-   * Test case for a single direct debit debit
-   *
-   * @return string payment reference id for the direct debit transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Debit()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 13.42, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-  
-      $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-  
-      $this->paymentObject->debit();
-          
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for direct debit refund
-   *
-   * @param string $referenceId reference id of the direct debit to refund
-   *
-   * @return string payment reference id of the direct debit refund transaction
-   * @depends Debit
-   * @test
-   * @group connectionTest
-   */
-  public function Refund($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 3.54, $this->currency, $this->secret);
-  
-      $this->paymentObject->refund((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
-      $this->assertFalse($response[1]->isError(), 'authorizet on registration failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a single direct debit debit
-   *
-   * @return string payment reference id for the direct debit transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Registration()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 13.42, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-  
-      $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-  
-      $this->paymentObject->registration();
-       
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a direct debit reversal of a existing authorisation
-   *
-   * @param string $referenceId payment reference id of the direct debit authorisation
-   *
-   * @return string payment reference id for the credit card reversal transaction
-   * @depends Authorize
-   * @test
-   * @group connectionTest
-   */
-  public function Reversal($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
-  
-      $this->paymentObject->reversal((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'reversal is pending');
-      $this->assertFalse($response[1]->isError(), 'reversal failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Tast case for a direct debit rebill of an existing debit or capture
-   *
-   * @param $referenceId string payment reference id of the direct debit debit or capture
-   *
-   * @return string payment reference id for the direct debit rebill transaction
-   * @depends Debit
-   * @test
-   * @group connectionTest
-   */
-  public function Rebill($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 12.12, $this->currency, $this->secret);
+
+    /**
+     * Test case for a single direct debit debit
+     *
+     * @return string payment reference id for the direct debit transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Debit()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 13.42, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+
+        $this->paymentObject->debit();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for direct debit refund
+     *
+     * @param string $referenceId reference id of the direct debit to refund
+     *
+     * @return string payment reference id of the direct debit refund transaction
+     * @depends Debit
+     * @test
+     * @group connectionTest
+     */
+    public function Refund($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 3.54, $this->currency, $this->secret);
+
+        $this->paymentObject->refund((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
+        $this->assertFalse($response[1]->isError(),
+            'authorizet on registration failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a single direct debit debit
+     *
+     * @return string payment reference id for the direct debit transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Registration()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 13.42, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+
+        $this->paymentObject->registration();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a direct debit reversal of a existing authorisation
+     *
+     * @param string $referenceId payment reference id of the direct debit authorisation
+     *
+     * @return string payment reference id for the credit card reversal transaction
+     * @depends Authorize
+     * @test
+     * @group connectionTest
+     */
+    public function Reversal($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
+
+        $this->paymentObject->reversal((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'reversal is pending');
+        $this->assertFalse($response[1]->isError(), 'reversal failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Tast case for a direct debit rebill of an existing debit or capture
+     *
+     * @param $referenceId string payment reference id of the direct debit debit or capture
+     *
+     * @return string payment reference id for the direct debit rebill transaction
+     * @depends Debit
+     * @test
+     * @group connectionTest
+     */
+    public function Rebill($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 12.12, $this->currency, $this->secret);
 
 
-  
-      $this->paymentObject->rebill((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'reversal is pending');
-      $this->assertFalse($response[1]->isError(), 'reversal failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for direct debit authorisation on a registration
-   *
-   * @param $referenceId string reference id of the direct debit registration
-   *
-   * @return string payment reference id of the direct debit authorisation
-   * @depends Registration
-   * @test
-   * @group  connectionTest
-   */
-  public function AuthorizeOnRegistration($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->rebill((string)$referenceId);
 
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
 
-      $this->paymentObject->authorizeOnRegistration((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
-      $this->assertFalse($response[1]->isError(), 'authorizet on registration failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'reversal is pending');
+        $this->assertFalse($response[1]->isError(), 'reversal failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for direct debit authorisation on a registration
+     *
+     * @param $referenceId string reference id of the direct debit registration
+     *
+     * @return string payment reference id of the direct debit authorisation
+     * @depends Registration
+     * @test
+     * @group  connectionTest
+     */
+    public function AuthorizeOnRegistration($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->authorizeOnRegistration((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
+        $this->assertFalse($response[1]->isError(),
+            'authorizet on registration failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 
     /**
      * Test case for a invoice finalize of a existing authorisation
@@ -379,7 +380,7 @@ class DirectDebitB2CSecuredMethodTest extends TestCase
         $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
         $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
 
-        $this->paymentObject->_dryRun=false;
+        $this->paymentObject->_dryRun = false;
 
         $this->paymentObject->finalize($referenceId);
 

--- a/tests/Unit/PaymentMethods/DirectDebitMethodTest.php
+++ b/tests/Unit/PaymentMethods/DirectDebitMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
-use Heidelpay\PhpApi\PaymentMethods\DirectDebitPaymentMethod as  DirectDebit;
+use Heidelpay\PhpApi\PaymentMethods\DirectDebitPaymentMethod as DirectDebit;
 
 /**
+ * Direct debit Test
  *
- *  Direct debit Test
- *
- *  Connection tests can fail due to network issues and scheduled downtime.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtime.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -35,13 +35,13 @@ class DirectDebitPaymentMethodTest extends TestCase
      *
      * @var string UserLogin
      */
-    protected $UserLogin      = '31ha07bc8142c5a171744e5aef11ffd3';
+    protected $UserLogin = '31ha07bc8142c5a171744e5aef11ffd3';
     /**
      * UserPassword
      *
      * @var string UserPassword
      */
-    protected $UserPassword   = '93167DE7';
+    protected $UserPassword = '93167DE7';
     /**
      * TransactionChannel
      *
@@ -56,7 +56,7 @@ class DirectDebitPaymentMethodTest extends TestCase
      * @var string
      */
     protected $SandboxRequest = true;
-    
+
     /**
      * Customer given name
      *
@@ -68,7 +68,7 @@ class DirectDebitPaymentMethodTest extends TestCase
      *
      * @var string nameFamily
      */
-    protected $nameFamily ='Berger-Payment';
+    protected $nameFamily = 'Berger-Payment';
     /**
      * Customer company name
      *
@@ -92,19 +92,19 @@ class DirectDebitPaymentMethodTest extends TestCase
      *
      * @var string addressState
      */
-    protected $addressState  = 'DE-BW';
+    protected $addressState = 'DE-BW';
     /**
      * customer billing address zip
      *
      * @var string addressZip
      */
-    protected $addressZip    = '69115';
+    protected $addressZip = '69115';
     /**
      * customer billing address city
      *
      * @var string addressCity
      */
-    protected $addressCity    = 'Heidelberg';
+    protected $addressCity = 'Heidelberg';
     /**
      * customer billing address city
      *
@@ -117,21 +117,21 @@ class DirectDebitPaymentMethodTest extends TestCase
      * @var string contactMail
      */
     protected $contactMail = "development@heidelpay.de";
-    
+
     /**
      * customer mail address
      *
      * @var string contactMail
      */
     protected $iban = "DE89370400440532013000";
-    
+
     /**
      * customer mail address
      *
      * @var string contactMail
      */
     protected $holder = "Heidel Berger-Payment";
-    
+
     /**
      * Transaction currency
      *
@@ -149,7 +149,7 @@ class DirectDebitPaymentMethodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -160,72 +160,76 @@ class DirectDebitPaymentMethodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a direct debit object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $DirectDebit = new DirectDebit();
-    
-      $DirectDebit->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword, $this->TransactionChannel, 'TRUE');
-    
-      $DirectDebit->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId, $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry, $this->contactMail);
-    
-    
-      $DirectDebit->_dryRun=true;
-    
-      $this->paymentObject = $DirectDebit;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single direct debit authorize
-   *
-   * @return string payment reference id for the direct debit transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Authorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+    /**
+     * Set up function will create a direct debit object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $DirectDebit = new DirectDebit();
 
-      $this->paymentObject->setAdapter('\Heidelpay\PhpApi\Adapter\CurlAdapter');
-      
-      $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+        $DirectDebit->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword,
+            $this->TransactionChannel, 'TRUE');
 
-      $this->paymentObject->_dryRun=false;
+        $DirectDebit->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId,
+            $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry,
+            $this->contactMail);
 
-      $this->paymentObject->authorize();
-      
 
-      $this->assertTrue($this->paymentObject->getResponse()->isSuccess(), 'Transaction failed : '.print_r($this->paymentObject->getResponse(), 1));
-      $this->assertFalse($this->paymentObject->getResponse()->isError(),
-          'authorize failed : '.print_r($this->paymentObject->getResponse()->getError(), 1));
-      
-      return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
-  }
+        $DirectDebit->_dryRun = true;
+
+        $this->paymentObject = $DirectDebit;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * Test case for a single direct debit authorize
+     *
+     * @return string payment reference id for the direct debit transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Authorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->setAdapter('\Heidelpay\PhpApi\Adapter\CurlAdapter');
+
+        $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+
+        $this->paymentObject->_dryRun = false;
+
+        $this->paymentObject->authorize();
+
+
+        $this->assertTrue($this->paymentObject->getResponse()->isSuccess(),
+            'Transaction failed : ' . print_r($this->paymentObject->getResponse(), 1));
+        $this->assertFalse($this->paymentObject->getResponse()->isError(),
+            'authorize failed : ' . print_r($this->paymentObject->getResponse()->getError(), 1));
+
+        return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
+    }
 
     /**
      * Capture Test
@@ -237,193 +241,195 @@ class DirectDebitPaymentMethodTest extends TestCase
      *
      * @return string
      */
-    public function Capture($referenceId=null)
+    public function Capture($referenceId = null)
     {
-        $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
         $this->paymentObject->getRequest()->basketData($timestamp, 13.12, $this->currency, $this->secret);
-  
+
         $this->paymentObject->capture((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-        $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
         $this->assertFalse($response[1]->isPending(), 'capture is pending');
-        $this->assertFalse($response[1]->isError(), 'capture failed : '.print_r($response[1]->getError(), 1));
-  
+        $this->assertFalse($response[1]->isError(), 'capture failed : ' . print_r($response[1]->getError(), 1));
+
         return (string)$response[1]->getPaymentReferenceId();
     }
-  
-  /**
-   * Test case for a single direct debit debit
-   *
-   * @return string payment reference id for the direct debit transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Debit()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 13.42, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-  
-      $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-  
-      $this->paymentObject->debit();
-          
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for direct debit refund
-   *
-   * @param string $referenceId reference id of the direct debit to refund
-   *
-   * @return string payment reference id of the direct debit refund transaction
-   * @depends Debit
-   * @test
-   * @group connectionTest
-   */
-  public function Refund($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 3.54, $this->currency, $this->secret);
-  
-      $this->paymentObject->refund((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
-      $this->assertFalse($response[1]->isError(), 'authorizet on registration failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a single direct debit debit
-   *
-   * @return string payment reference id for the direct debit transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Registration()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 13.42, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-  
-      $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
-      $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
-  
-      $this->paymentObject->registration();
-       
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a direct debit reversal of a existing authorisation
-   *
-   * @param string $referenceId payment reference id of the direct debit authorisation
-   *
-   * @return string payment reference id for the credit card reversal transaction
-   * @depends Authorize
-   * @test
-   * @group connectionTest
-   */
-  public function Reversal($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
-  
-      $this->paymentObject->reversal((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'reversal is pending');
-      $this->assertFalse($response[1]->isError(), 'reversal failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Tast case for a direct debit rebill of an existing debit or capture
-   *
-   * @param $referenceId string payment reference id of the direct debit debit or capture
-   *
-   * @return string payment reference id for the direct debit rebill transaction
-   * @depends Debit
-   * @test
-   * @group connectionTest
-   */
-  public function Rebill($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
-  
-      $this->paymentObject->rebill((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'reversal is pending');
-      $this->assertFalse($response[1]->isError(), 'reversal failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for direct debit authorisation on a registration
-   *
-   * @param $referenceId string reference id of the direct debit registration
-   *
-   * @return string payment reference id of the direct debit authorisation
-   * @depends Registration
-   * @test
-   * @group  connectionTest
-   */
-  public function AuthorizeOnRegistration($referenceId=null)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
 
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+    /**
+     * Test case for a single direct debit debit
+     *
+     * @return string payment reference id for the direct debit transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Debit()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 13.42, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
 
-      $this->paymentObject->authorizeOnRegistration((string)$referenceId);
-  
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-  
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1]->getError(), 1));
-      $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
-      $this->assertFalse($response[1]->isError(), 'authorizet on registration failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+        $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+
+        $this->paymentObject->debit();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for direct debit refund
+     *
+     * @param string $referenceId reference id of the direct debit to refund
+     *
+     * @return string payment reference id of the direct debit refund transaction
+     * @depends Debit
+     * @test
+     * @group connectionTest
+     */
+    public function Refund($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 3.54, $this->currency, $this->secret);
+
+        $this->paymentObject->refund((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
+        $this->assertFalse($response[1]->isError(),
+            'authorizet on registration failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a single direct debit debit
+     *
+     * @return string payment reference id for the direct debit transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Registration()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 13.42, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->getRequest()->getAccount()->set('iban', $this->iban);
+        $this->paymentObject->getRequest()->getAccount()->set('holder', $this->holder);
+
+        $this->paymentObject->registration();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a direct debit reversal of a existing authorisation
+     *
+     * @param string $referenceId payment reference id of the direct debit authorisation
+     *
+     * @return string payment reference id for the credit card reversal transaction
+     * @depends Authorize
+     * @test
+     * @group connectionTest
+     */
+    public function Reversal($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
+
+        $this->paymentObject->reversal((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'reversal is pending');
+        $this->assertFalse($response[1]->isError(), 'reversal failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Tast case for a direct debit rebill of an existing debit or capture
+     *
+     * @param $referenceId string payment reference id of the direct debit debit or capture
+     *
+     * @return string payment reference id for the direct debit rebill transaction
+     * @depends Debit
+     * @test
+     * @group connectionTest
+     */
+    public function Rebill($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
+
+        $this->paymentObject->rebill((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'reversal is pending');
+        $this->assertFalse($response[1]->isError(), 'reversal failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for direct debit authorisation on a registration
+     *
+     * @param $referenceId string reference id of the direct debit registration
+     *
+     * @return string payment reference id of the direct debit authorisation
+     * @depends Registration
+     * @test
+     * @group  connectionTest
+     */
+    public function AuthorizeOnRegistration($referenceId = null)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
+
+        $this->paymentObject->authorizeOnRegistration((string)$referenceId);
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1]->getError(), 1));
+        $this->assertFalse($response[1]->isPending(), 'authorize on registration is pending');
+        $this->assertFalse($response[1]->isError(),
+            'authorizet on registration failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 }

--- a/tests/Unit/PaymentMethods/EPSPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/EPSPaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\PaymentMethods\EPSPaymentMethod as EPS;
 
 /**
+ * EPS Test
  *
- *  EPS Test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -35,13 +35,13 @@ class EPSPaymentMerhodTest extends TestCase
      *
      * @var string UserLogin
      */
-    protected $UserLogin      = '31ha07bc8124ad82a9e96d486d19edaa';
+    protected $UserLogin = '31ha07bc8124ad82a9e96d486d19edaa';
     /**
      * UserPassword
      *
      * @var string UserPassword
      */
-    protected $UserPassword   = 'password';
+    protected $UserPassword = 'password';
     /**
      * TransactionChannel
      *
@@ -88,7 +88,7 @@ class EPSPaymentMerhodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -99,62 +99,63 @@ class EPSPaymentMerhodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a EPS object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $EPS = new EPS();
-    
-      $EPS->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword, $this->TransactionChannel, 'TRUE');
-    
-      $EPS->getRequest()->customerAddress(...$this->customerDetails);
-    
-      $EPS->_dryRun=true;
-    
-      $this->paymentObject = $EPS;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single EPS authorize
-   *
-   * @return string payment reference id for the EPS authorize transaction
-   * @group connectionTest
-   */
-  public function testAuthorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      
-      $this->paymentObject->authorize();
+    /**
+     * Set up function will create a EPS object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $EPS = new EPS();
 
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+        $EPS->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword,
+            $this->TransactionChannel, 'TRUE');
+
+        $EPS->getRequest()->customerAddress(...$this->customerDetails);
+
+        $EPS->_dryRun = true;
+
+        $this->paymentObject = $EPS;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * Test case for a single EPS authorize
+     *
+     * @return string payment reference id for the EPS authorize transaction
+     * @group connectionTest
+     */
+    public function testAuthorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+
+        $this->paymentObject->authorize();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 }

--- a/tests/Unit/PaymentMethods/GiropayPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/GiropayPaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\PaymentMethods\GiropayPaymentMethod as Giropay;
 
 /**
+ * Giropay Test
  *
- *  Giropay Test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -35,13 +35,13 @@ class GiropayPaymentMerhodTest extends TestCase
      *
      * @var string UserLogin
      */
-    protected $UserLogin      = '31ha07bc8142c5a171744e5aef11ffd3';
+    protected $UserLogin = '31ha07bc8142c5a171744e5aef11ffd3';
     /**
      * UserPassword
      *
      * @var string UserPassword
      */
-    protected $UserPassword   = '93167DE7';
+    protected $UserPassword = '93167DE7';
     /**
      * TransactionChannel
      *
@@ -56,7 +56,7 @@ class GiropayPaymentMerhodTest extends TestCase
      * @var string
      */
     protected $SandboxRequest = true;
-    
+
     /**
      * Customer given name
      *
@@ -68,7 +68,7 @@ class GiropayPaymentMerhodTest extends TestCase
      *
      * @var string nameFamily
      */
-    protected $nameFamily ='Berger-Payment';
+    protected $nameFamily = 'Berger-Payment';
     /**
      * Customer company name
      *
@@ -92,19 +92,19 @@ class GiropayPaymentMerhodTest extends TestCase
      *
      * @var string addressState
      */
-    protected $addressState  = 'DE-BW';
+    protected $addressState = 'DE-BW';
     /**
      * customer billing address zip
      *
      * @var string addressZip
      */
-    protected $addressZip    = '69115';
+    protected $addressZip = '69115';
     /**
      * customer billing address city
      *
      * @var string addressCity
      */
-    protected $addressCity    = 'Heidelberg';
+    protected $addressCity = 'Heidelberg';
     /**
      * customer billing address city
      *
@@ -117,7 +117,7 @@ class GiropayPaymentMerhodTest extends TestCase
      * @var string contactMail
      */
     protected $contactMail = "development@heidelpay.de";
-    
+
     /**
      * Transaction currency
      *
@@ -135,7 +135,7 @@ class GiropayPaymentMerhodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -146,63 +146,66 @@ class GiropayPaymentMerhodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a Giropay object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $Giropay = new Giropay();
-    
-      $Giropay->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword, $this->TransactionChannel, 'TRUE');
-    
-      $Giropay->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId, $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry, $this->contactMail);
-    
-    
-      $Giropay->_dryRun=true;
-    
-      $this->paymentObject = $Giropay;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single Giropay authorize
-   *
-   * @return string payment reference id for the Giropay authorize transaction
-   * @group connectionTest
-   */
-  public function testAuthorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      
-      $this->paymentObject->authorize();
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+    /**
+     * Set up function will create a Giropay object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $Giropay = new Giropay();
+
+        $Giropay->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword,
+            $this->TransactionChannel, 'TRUE');
+
+        $Giropay->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId,
+            $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry,
+            $this->contactMail);
+
+
+        $Giropay->_dryRun = true;
+
+        $this->paymentObject = $Giropay;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * Test case for a single Giropay authorize
+     *
+     * @return string payment reference id for the Giropay authorize transaction
+     * @group connectionTest
+     */
+    public function testAuthorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+
+        $this->paymentObject->authorize();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 }

--- a/tests/Unit/PaymentMethods/IDealPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/IDealPaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
-use Heidelpay\PhpApi\PaymentMethods\IDealPaymentMethod as  iDeal;
+use Heidelpay\PhpApi\PaymentMethods\IDealPaymentMethod as iDeal;
 
 /**
+ * iDeal Test
  *
- *  iDeal Test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -35,13 +35,13 @@ class IdealPaymentMerhodTest extends TestCase
      *
      * @var string UserLogin
      */
-    protected $UserLogin      = '31ha07bc8142c5a171744e5aef11ffd3';
+    protected $UserLogin = '31ha07bc8142c5a171744e5aef11ffd3';
     /**
      * UserPassword
      *
      * @var string UserPassword
      */
-    protected $UserPassword   = '93167DE7';
+    protected $UserPassword = '93167DE7';
     /**
      * TransactionChannel
      *
@@ -56,7 +56,7 @@ class IdealPaymentMerhodTest extends TestCase
      * @var string
      */
     protected $SandboxRequest = true;
-    
+
     /**
      * Customer given name
      *
@@ -68,7 +68,7 @@ class IdealPaymentMerhodTest extends TestCase
      *
      * @var string nameFamily
      */
-    protected $nameFamily ='Berger-Payment';
+    protected $nameFamily = 'Berger-Payment';
     /**
      * Customer company name
      *
@@ -92,19 +92,19 @@ class IdealPaymentMerhodTest extends TestCase
      *
      * @var string addressState
      */
-    protected $addressState  = 'DE-BW';
+    protected $addressState = 'DE-BW';
     /**
      * customer billing address zip
      *
      * @var string addressZip
      */
-    protected $addressZip    = '69115';
+    protected $addressZip = '69115';
     /**
      * customer billing address city
      *
      * @var string addressCity
      */
-    protected $addressCity    = 'Heidelberg';
+    protected $addressCity = 'Heidelberg';
     /**
      * customer billing address city
      *
@@ -117,7 +117,7 @@ class IdealPaymentMerhodTest extends TestCase
      * @var string contactMail
      */
     protected $contactMail = "development@heidelpay.de";
-    
+
     /**
      * Transaction currency
      *
@@ -135,7 +135,7 @@ class IdealPaymentMerhodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -146,78 +146,80 @@ class IdealPaymentMerhodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a sofort object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $iDeal = new iDeal();
-    
-      $iDeal->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword, $this->TransactionChannel, 'TRUE');
-    
-      $iDeal->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId, $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry, $this->contactMail);
-    
-    
-      $iDeal->_dryRun=true;
-    
-      $this->paymentObject = $iDeal;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single iDeal authorize
-   *
-   * @return string payment reference id for the iDeal authorize transaction
-   * @group connectionTest
-   */
-  public function testAuthorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      
-      $this->paymentObject->authorize();
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      /* test if config parameters exists */
-      $configBankCountry = array('NL' => 'Niederlande');
-      
-      $this->assertEquals($configBankCountry, $response[1]->getConfig()->getBankCountry());
-      
-      $configBrands = array(
+    /**
+     * Set up function will create a sofort object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $iDeal = new iDeal();
+
+        $iDeal->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword,
+            $this->TransactionChannel, 'TRUE');
+
+        $iDeal->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId,
+            $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry,
+            $this->contactMail);
+
+
+        $iDeal->_dryRun = true;
+
+        $this->paymentObject = $iDeal;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * Test case for a single iDeal authorize
+     *
+     * @return string payment reference id for the iDeal authorize transaction
+     * @group connectionTest
+     */
+    public function testAuthorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+
+        $this->paymentObject->authorize();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        /* test if config parameters exists */
+        $configBankCountry = array('NL' => 'Niederlande');
+
+        $this->assertEquals($configBankCountry, $response[1]->getConfig()->getBankCountry());
+
+        $configBrands = array(
             'ING_TEST' => 'Test Bank',
             'INGBNL2A' => 'Issuer Simulation V3 - ING',
             'RABONL2U' => 'Issuer Simulation V3 - RABO'
-      );
-        
-      $this->assertEquals($configBrands, $response[1]->getConfig()->getBrands());
-      
-      
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+        );
+
+        $this->assertEquals($configBrands, $response[1]->getConfig()->getBrands());
+
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 }

--- a/tests/Unit/PaymentMethods/InvoiceB2CSecuredPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/InvoiceB2CSecuredPaymentMethodTest.php
@@ -6,11 +6,10 @@ use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\PaymentMethods\InvoiceB2CSecuredPaymentMethod as Invoice;
 
 /**
- *,
- *  Invoice B2C secured Test
+ * Invoice B2C secured Test
  *
- *  Connection tests can fail due to network issues and scheduled downtime.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtime.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,7 +24,6 @@ use Heidelpay\PhpApi\PaymentMethods\InvoiceB2CSecuredPaymentMethod as Invoice;
  */
 class InvoiceB2CSecuredPaymentMethodTest extends TestCase
 {
-
     /**
      * @var array authentification parameter for heidelpay api
      */
@@ -176,7 +174,6 @@ class InvoiceB2CSecuredPaymentMethodTest extends TestCase
     /**
      * Test case for a invoice reversal of a existing authorisation
      *
-
      *
      * @return string payment reference id for the prepayment reversal transaction
      * @depends Finalize

--- a/tests/Unit/PaymentMethods/InvoicePaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/InvoicePaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
-use Heidelpay\PhpApi\PaymentMethods\InvoicePaymentMethod as  Invoice;
+use Heidelpay\PhpApi\PaymentMethods\InvoicePaymentMethod as Invoice;
 
 /**
+ * Invoice Test
  *
- *  Invoice Test
- *
- *  Connection tests can fail due to network issues and scheduled downtime.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtime.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -24,7 +24,6 @@ use Heidelpay\PhpApi\PaymentMethods\InvoicePaymentMethod as  Invoice;
  */
 class InvoicePaymentMethodTest extends TestCase
 {
-
     /**
      * @var array authentification parameter for heidelpay api
      */
@@ -48,7 +47,7 @@ class InvoicePaymentMethodTest extends TestCase
         'DE', //AddressCountry
         'development@heidelpay.de' //Costumer
     );
-    
+
     /**
      * Transaction currency
      *
@@ -66,7 +65,7 @@ class InvoicePaymentMethodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -77,97 +76,97 @@ class InvoicePaymentMethodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-      parent::__construct();
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+        parent::__construct();
+    }
 
-  /**
-   * Set up function will create a invoice object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $Invoice = new Invoice();
-    
-      $Invoice->getRequest()->authentification(...$this->authentification);
-    
-      $Invoice->getRequest()->customerAddress(...$this->customerDetails);
+    /**
+     * Set up function will create a invoice object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $Invoice = new Invoice();
 
-      $this->paymentObject = $Invoice;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single invoice authorisation
-   *
-   * @return string payment reference id for the invoice authorize transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Authorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
-      
-      $this->paymentObject->authorize();
-      
-      /* verify response */
-      $this->assertTrue($this->paymentObject->getResponse()->verifySecurityHash($this->secret, $timestamp));
+        $Invoice->getRequest()->authentification(...$this->authentification);
 
-      /* transaction result */
-      $this->assertTrue($this->paymentObject->getResponse()->isSuccess(),
-          'Transaction failed : '.print_r($this->paymentObject->getResponse(), 1));
-      $this->assertFalse($this->paymentObject->getResponse()->isPending(), 'authorize is pending');
-      $this->assertFalse($this->paymentObject->getResponse()->isError(),
-          'authorize failed : '.print_r($this->paymentObject->getResponse()->getError(), 1));
+        $Invoice->getRequest()->customerAddress(...$this->customerDetails);
 
-      return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a invoice reversal of a existing authorisation
-   *
-   * @param $referenceId string payment reference id of the invoice authorisation
-   *
-   * @return string payment reference id for the prepayment reversal transaction
-   * @depends Authorize
-   * @group connectionTest
-   * @test   *
-   */
-  public function Reversal($referenceId)
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
-  
-      $this->paymentObject->reversal($referenceId);
+        $this->paymentObject = $Invoice;
+    }
 
-      /* verify response */
-      $this->assertTrue($this->paymentObject->getResponse()->verifySecurityHash($this->secret, $timestamp));
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
 
-      /* transaction result */
-      $this->assertTrue($this->paymentObject->getResponse()->isSuccess(),
-          'Transaction failed : '.print_r($this->paymentObject->getResponse(), 1));
-      $this->assertFalse($this->paymentObject->getResponse()->isPending(), 'reversal is pending');
-      $this->assertFalse($this->paymentObject->getResponse()->isError(),
-          'reversal failed : '.print_r($this->paymentObject->getResponse()->getError(), 1));
+    /**
+     * Test case for a single invoice authorisation
+     *
+     * @return string payment reference id for the invoice authorize transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Authorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
 
-      return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
-  }
+        $this->paymentObject->authorize();
+
+        /* verify response */
+        $this->assertTrue($this->paymentObject->getResponse()->verifySecurityHash($this->secret, $timestamp));
+
+        /* transaction result */
+        $this->assertTrue($this->paymentObject->getResponse()->isSuccess(),
+            'Transaction failed : ' . print_r($this->paymentObject->getResponse(), 1));
+        $this->assertFalse($this->paymentObject->getResponse()->isPending(), 'authorize is pending');
+        $this->assertFalse($this->paymentObject->getResponse()->isError(),
+            'authorize failed : ' . print_r($this->paymentObject->getResponse()->getError(), 1));
+
+        return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a invoice reversal of a existing authorisation
+     *
+     * @param $referenceId string payment reference id of the invoice authorisation
+     *
+     * @return string payment reference id for the prepayment reversal transaction
+     * @depends Authorize
+     * @group connectionTest
+     * @test   *
+     */
+    public function Reversal($referenceId)
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
+
+        $this->paymentObject->reversal($referenceId);
+
+        /* verify response */
+        $this->assertTrue($this->paymentObject->getResponse()->verifySecurityHash($this->secret, $timestamp));
+
+        /* transaction result */
+        $this->assertTrue($this->paymentObject->getResponse()->isSuccess(),
+            'Transaction failed : ' . print_r($this->paymentObject->getResponse(), 1));
+        $this->assertFalse($this->paymentObject->getResponse()->isPending(), 'reversal is pending');
+        $this->assertFalse($this->paymentObject->getResponse()->isError(),
+            'reversal failed : ' . print_r($this->paymentObject->getResponse()->getError(), 1));
+
+        return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
+    }
 
     /**
      * Test case for invoice refund
@@ -179,9 +178,9 @@ class InvoicePaymentMethodTest extends TestCase
      * @test
      * @group connectionTest
      */
-    public function Refund($referenceId=null)
+    public function Refund($referenceId = null)
     {
-        $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
         $this->paymentObject->getRequest()->basketData($timestamp, 3.54, $this->currency, $this->secret);
 
         /* the refund can not be processed because there will be no receipt automatically on the sandbox */

--- a/tests/Unit/PaymentMethods/PayPalPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/PayPalPaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
-use Heidelpay\PhpApi\PaymentMethods\PayPalPaymentMethod as  PayPal;
+use Heidelpay\PhpApi\PaymentMethods\PayPalPaymentMethod as PayPal;
 
 /**
+ * PayPal Test
  *
- *  PayPal Test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -35,13 +35,13 @@ class PayPalPaymentMerhodTest extends TestCase
      *
      * @var string UserLogin
      */
-    protected $UserLogin      = '31ha07bc8142c5a171744e5aef11ffd3';
+    protected $UserLogin = '31ha07bc8142c5a171744e5aef11ffd3';
     /**
      * UserPassword
      *
      * @var string UserPassword
      */
-    protected $UserPassword   = '93167DE7';
+    protected $UserPassword = '93167DE7';
     /**
      * TransactionChannel
      *
@@ -56,7 +56,7 @@ class PayPalPaymentMerhodTest extends TestCase
      * @var string
      */
     protected $SandboxRequest = true;
-    
+
     /**
      * Customer given name
      *
@@ -68,7 +68,7 @@ class PayPalPaymentMerhodTest extends TestCase
      *
      * @var string nameFamily
      */
-    protected $nameFamily ='Berger-Payment';
+    protected $nameFamily = 'Berger-Payment';
     /**
      * Customer company name
      *
@@ -92,19 +92,19 @@ class PayPalPaymentMerhodTest extends TestCase
      *
      * @var string addressState
      */
-    protected $addressState  = 'DE-BW';
+    protected $addressState = 'DE-BW';
     /**
      * customer billing address zip
      *
      * @var string addressZip
      */
-    protected $addressZip    = '69115';
+    protected $addressZip = '69115';
     /**
      * customer billing address city
      *
      * @var string addressCity
      */
-    protected $addressCity    = 'Heidelberg';
+    protected $addressCity = 'Heidelberg';
     /**
      * customer billing address city
      *
@@ -117,7 +117,7 @@ class PayPalPaymentMerhodTest extends TestCase
      * @var string contactMail
      */
     protected $contactMail = "development@heidelpay.de";
-    
+
     /**
      * Transaction currency
      *
@@ -135,7 +135,7 @@ class PayPalPaymentMerhodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -146,88 +146,91 @@ class PayPalPaymentMerhodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a PayPal object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $PayPal = new PayPal();
-    
-      $PayPal->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword, $this->TransactionChannel, 'TRUE');
-    
-      $PayPal->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId, $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry, $this->contactMail);
-    
-    
-      $PayPal->_dryRun=true;
-    
-      $this->paymentObject = $PayPal;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single PayPal authorisation
-   *
-   * @return string payment reference id for the PayPal authorize transaction
-   * @group connectionTest
-   */
-  public function testAuthorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      
-      $this->paymentObject->authorize();
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
-  
-  /**
-   * Test case for a single PayPal debit
-   *
-   * @return string payment reference id for the PayPal authorize transaction
-   * @group connectionTest
-   */
-  public function testDebit()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      
-  
-      $this->paymentObject->debit();
-          
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'debit failed : '.print_r($response[1]->getError(), 1));
-  
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+    /**
+     * Set up function will create a PayPal object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $PayPal = new PayPal();
+
+        $PayPal->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword,
+            $this->TransactionChannel, 'TRUE');
+
+        $PayPal->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId,
+            $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry,
+            $this->contactMail);
+
+
+        $PayPal->_dryRun = true;
+
+        $this->paymentObject = $PayPal;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * Test case for a single PayPal authorisation
+     *
+     * @return string payment reference id for the PayPal authorize transaction
+     * @group connectionTest
+     */
+    public function testAuthorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+
+        $this->paymentObject->authorize();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
+
+    /**
+     * Test case for a single PayPal debit
+     *
+     * @return string payment reference id for the PayPal authorize transaction
+     * @group connectionTest
+     */
+    public function testDebit()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+
+
+        $this->paymentObject->debit();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'debit failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 }

--- a/tests/Unit/PaymentMethods/PostFinanceCardPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/PostFinanceCardPaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\PaymentMethods\PostFinanceCardPaymentMethod as PostFinanceCard;
 
 /**
+ * PostFinanceCard Test
  *
- *  PostFinanceCard Test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -35,13 +35,13 @@ class PostFinanceCardPaymentMerhodTest extends TestCase
      *
      * @var string UserLogin
      */
-    protected $UserLogin      = '31ha07bc8142c5a171744e5aef11ffd3';
+    protected $UserLogin = '31ha07bc8142c5a171744e5aef11ffd3';
     /**
      * UserPassword
      *
      * @var string UserPassword
      */
-    protected $UserPassword   = '93167DE7';
+    protected $UserPassword = '93167DE7';
     /**
      * TransactionChannel
      *
@@ -56,7 +56,7 @@ class PostFinanceCardPaymentMerhodTest extends TestCase
      * @var string
      */
     protected $SandboxRequest = true;
-    
+
     /**
      * Customer given name
      *
@@ -68,7 +68,7 @@ class PostFinanceCardPaymentMerhodTest extends TestCase
      *
      * @var string nameFamily
      */
-    protected $nameFamily ='Berger-Payment';
+    protected $nameFamily = 'Berger-Payment';
     /**
      * Customer company name
      *
@@ -92,19 +92,19 @@ class PostFinanceCardPaymentMerhodTest extends TestCase
      *
      * @var string addressState
      */
-    protected $addressState  = 'DE-BW';
+    protected $addressState = 'DE-BW';
     /**
      * customer billing address zip
      *
      * @var string addressZip
      */
-    protected $addressZip    = '69115';
+    protected $addressZip = '69115';
     /**
      * customer billing address city
      *
      * @var string addressCity
      */
-    protected $addressCity    = 'Heidelberg';
+    protected $addressCity = 'Heidelberg';
     /**
      * customer billing address city
      *
@@ -117,7 +117,7 @@ class PostFinanceCardPaymentMerhodTest extends TestCase
      * @var string contactMail
      */
     protected $contactMail = "development@heidelpay.de";
-    
+
     /**
      * Transaction currency
      *
@@ -135,7 +135,7 @@ class PostFinanceCardPaymentMerhodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -146,63 +146,66 @@ class PostFinanceCardPaymentMerhodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a PostFinanceCard object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $PostFinanceCard = new PostFinanceCard();
-    
-      $PostFinanceCard->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword, $this->TransactionChannel, 'TRUE');
-    
-      $PostFinanceCard->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId, $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry, $this->contactMail);
-    
-    
-      $PostFinanceCard->_dryRun=true;
-    
-      $this->paymentObject = $PostFinanceCard;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single PostFinanceCard authorize
-   *
-   * @return string payment reference id for the PostFinanceCard authorize transaction
-   * @group connectionTest
-   */
-  public function testAuthorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      
-      $this->paymentObject->authorize();
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+    /**
+     * Set up function will create a PostFinanceCard object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $PostFinanceCard = new PostFinanceCard();
+
+        $PostFinanceCard->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword,
+            $this->TransactionChannel, 'TRUE');
+
+        $PostFinanceCard->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId,
+            $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry,
+            $this->contactMail);
+
+
+        $PostFinanceCard->_dryRun = true;
+
+        $this->paymentObject = $PostFinanceCard;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * Test case for a single PostFinanceCard authorize
+     *
+     * @return string payment reference id for the PostFinanceCard authorize transaction
+     * @group connectionTest
+     */
+    public function testAuthorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+
+        $this->paymentObject->authorize();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 }

--- a/tests/Unit/PaymentMethods/PostFinanceEFinancePaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/PostFinanceEFinancePaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\PaymentMethods\PostFinanceEFinancePaymentMethod as PostFinanceEFinance;
 
 /**
+ * PostFinanceEFinance Test
  *
- *  PostFinanceEFinance Test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -35,13 +35,13 @@ class PostFinanceEFinancePaymentMerhodTest extends TestCase
      *
      * @var string UserLogin
      */
-    protected $UserLogin      = '31ha07bc8142c5a171744e5aef11ffd3';
+    protected $UserLogin = '31ha07bc8142c5a171744e5aef11ffd3';
     /**
      * UserPassword
      *
      * @var string UserPassword
      */
-    protected $UserPassword   = '93167DE7';
+    protected $UserPassword = '93167DE7';
     /**
      * TransactionChannel
      *
@@ -56,7 +56,7 @@ class PostFinanceEFinancePaymentMerhodTest extends TestCase
      * @var string
      */
     protected $SandboxRequest = true;
-    
+
     /**
      * Customer given name
      *
@@ -68,7 +68,7 @@ class PostFinanceEFinancePaymentMerhodTest extends TestCase
      *
      * @var string nameFamily
      */
-    protected $nameFamily ='Berger-Payment';
+    protected $nameFamily = 'Berger-Payment';
     /**
      * Customer company name
      *
@@ -92,19 +92,19 @@ class PostFinanceEFinancePaymentMerhodTest extends TestCase
      *
      * @var string addressState
      */
-    protected $addressState  = 'DE-BW';
+    protected $addressState = 'DE-BW';
     /**
      * customer billing address zip
      *
      * @var string addressZip
      */
-    protected $addressZip    = '69115';
+    protected $addressZip = '69115';
     /**
      * customer billing address city
      *
      * @var string addressCity
      */
-    protected $addressCity    = 'Heidelberg';
+    protected $addressCity = 'Heidelberg';
     /**
      * customer billing address city
      *
@@ -117,7 +117,7 @@ class PostFinanceEFinancePaymentMerhodTest extends TestCase
      * @var string contactMail
      */
     protected $contactMail = "development@heidelpay.de";
-    
+
     /**
      * Transaction currency
      *
@@ -135,7 +135,7 @@ class PostFinanceEFinancePaymentMerhodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -146,63 +146,66 @@ class PostFinanceEFinancePaymentMerhodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a PostFinanceEFinance object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $PostFinanceEFinance = new PostFinanceEFinance();
-    
-      $PostFinanceEFinance->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword, $this->TransactionChannel, 'TRUE');
-    
-      $PostFinanceEFinance->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId, $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry, $this->contactMail);
-    
-    
-      $PostFinanceEFinance->_dryRun=true;
-    
-      $this->paymentObject = $PostFinanceEFinance;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single PostFinanceEFinance authorize
-   *
-   * @return string payment reference id for the PostFinanceEFinance authorize transaction
-   * @group connectionTest
-   */
-  public function testAuthorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      
-      $this->paymentObject->authorize();
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+    /**
+     * Set up function will create a PostFinanceEFinance object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $PostFinanceEFinance = new PostFinanceEFinance();
+
+        $PostFinanceEFinance->getRequest()->authentification($this->SecuritySender, $this->UserLogin,
+            $this->UserPassword, $this->TransactionChannel, 'TRUE');
+
+        $PostFinanceEFinance->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId,
+            $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry,
+            $this->contactMail);
+
+
+        $PostFinanceEFinance->_dryRun = true;
+
+        $this->paymentObject = $PostFinanceEFinance;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * Test case for a single PostFinanceEFinance authorize
+     *
+     * @return string payment reference id for the PostFinanceEFinance authorize transaction
+     * @group connectionTest
+     */
+    public function testAuthorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+
+        $this->paymentObject->authorize();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 }

--- a/tests/Unit/PaymentMethods/PrepaymentPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/PrepaymentPaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
-use Heidelpay\PhpApi\PaymentMethods\PrepaymentPaymentMethod as  Prepayment;
+use Heidelpay\PhpApi\PaymentMethods\PrepaymentPaymentMethod as Prepayment;
 
 /**
+ * Prepayment Test
  *
- *  Prepayment Test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -65,7 +65,7 @@ class PrepaymentPaymentMethodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -76,39 +76,39 @@ class PrepaymentPaymentMethodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-      parent::__construct();
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+        parent::__construct();
+    }
 
-  /**
-   * Set up function will create a prepaymet object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $Prepayment = new Prepayment();
-    
-      $Prepayment->getRequest()->authentification(...$this->authentification);
-    
-      $Prepayment->getRequest()->customerAddress(...$this->customerDetails);
-        
-      $this->paymentObject = $Prepayment;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
+    /**
+     * Set up function will create a prepaymet object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $Prepayment = new Prepayment();
+
+        $Prepayment->getRequest()->authentification(...$this->authentification);
+
+        $Prepayment->getRequest()->customerAddress(...$this->customerDetails);
+
+        $this->paymentObject = $Prepayment;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
 
     /**
      * Test case for a single prepayment authorisation
@@ -119,7 +119,7 @@ class PrepaymentPaymentMethodTest extends TestCase
      */
     public function Authorize()
     {
-        $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
         $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
         $this->paymentObject->getRequest()->getFrontend()->set('enabled', 'FALSE');
 
@@ -130,10 +130,10 @@ class PrepaymentPaymentMethodTest extends TestCase
 
         /* transaction result */
         $this->assertTrue($this->paymentObject->getResponse()->isSuccess(),
-            'Transaction failed : '.print_r($this->paymentObject->getResponse(), 1));
+            'Transaction failed : ' . print_r($this->paymentObject->getResponse(), 1));
         $this->assertFalse($this->paymentObject->getResponse()->isPending(), 'authorize is pending');
         $this->assertFalse($this->paymentObject->getResponse()->isError(),
-            'authorize failed : '.print_r($this->paymentObject->getResponse()->getError(), 1));
+            'authorize failed : ' . print_r($this->paymentObject->getResponse()->getError(), 1));
 
         return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
     }
@@ -150,7 +150,7 @@ class PrepaymentPaymentMethodTest extends TestCase
      */
     public function Reversal($referenceId)
     {
-        $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
         $this->paymentObject->getRequest()->basketData($timestamp, 2.12, $this->currency, $this->secret);
 
         $this->paymentObject->reversal($referenceId);
@@ -160,10 +160,10 @@ class PrepaymentPaymentMethodTest extends TestCase
 
         /* transaction result */
         $this->assertTrue($this->paymentObject->getResponse()->isSuccess(),
-            'Transaction failed : '.print_r($this->paymentObject->getResponse(), 1));
+            'Transaction failed : ' . print_r($this->paymentObject->getResponse(), 1));
         $this->assertFalse($this->paymentObject->getResponse()->isPending(), 'reversal is pending');
         $this->assertFalse($this->paymentObject->getResponse()->isError(),
-            'reversal failed : '.print_r($this->paymentObject->getResponse()->getError(), 1));
+            'reversal failed : ' . print_r($this->paymentObject->getResponse()->getError(), 1));
 
         return (string)$this->paymentObject->getResponse()->getPaymentReferenceId();
     }
@@ -178,9 +178,9 @@ class PrepaymentPaymentMethodTest extends TestCase
      * @test
      * @group connectionTest
      */
-    public function Refund($referenceId=null)
+    public function Refund($referenceId = null)
     {
-        $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
         $this->paymentObject->getRequest()->basketData($timestamp, 3.54, $this->currency, $this->secret);
 
         /* the refund can not be processed because there will be no receipt automatically on the sandbox */

--- a/tests/Unit/PaymentMethods/Przelewy24PaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/Przelewy24PaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\PaymentMethods\Przelewy24PaymentMethod as Przelewy24;
 
 /**
+ * Przelewy24 Test
  *
- *  Przelewy24 Test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -35,13 +35,13 @@ class Przelewy24PaymentMerhodTest extends TestCase
      *
      * @var string UserLogin
      */
-    protected $UserLogin      = '31ha07bc8142c5a171744e5aef11ffd3';
+    protected $UserLogin = '31ha07bc8142c5a171744e5aef11ffd3';
     /**
      * UserPassword
      *
      * @var string UserPassword
      */
-    protected $UserPassword   = '93167DE7';
+    protected $UserPassword = '93167DE7';
     /**
      * TransactionChannel
      *
@@ -56,7 +56,7 @@ class Przelewy24PaymentMerhodTest extends TestCase
      * @var string
      */
     protected $SandboxRequest = true;
-    
+
     /**
      * Customer given name
      *
@@ -68,7 +68,7 @@ class Przelewy24PaymentMerhodTest extends TestCase
      *
      * @var string nameFamily
      */
-    protected $nameFamily ='Berger-Payment';
+    protected $nameFamily = 'Berger-Payment';
     /**
      * Customer company name
      *
@@ -92,19 +92,19 @@ class Przelewy24PaymentMerhodTest extends TestCase
      *
      * @var string addressState
      */
-    protected $addressState  = 'DE-BW';
+    protected $addressState = 'DE-BW';
     /**
      * customer billing address zip
      *
      * @var string addressZip
      */
-    protected $addressZip    = '69115';
+    protected $addressZip = '69115';
     /**
      * customer billing address city
      *
      * @var string addressCity
      */
-    protected $addressCity    = 'Heidelberg';
+    protected $addressCity = 'Heidelberg';
     /**
      * customer billing address city
      *
@@ -117,7 +117,7 @@ class Przelewy24PaymentMerhodTest extends TestCase
      * @var string contactMail
      */
     protected $contactMail = "development@heidelpay.de";
-    
+
     /**
      * Transaction currency
      *
@@ -135,7 +135,7 @@ class Przelewy24PaymentMerhodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -146,63 +146,66 @@ class Przelewy24PaymentMerhodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a Przelewy24 object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $Przelewy24 = new Przelewy24();
-    
-      $Przelewy24->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword, $this->TransactionChannel, 'TRUE');
-    
-      $Przelewy24->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId, $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry, $this->contactMail);
-    
-    
-      $Przelewy24->_dryRun=true;
-    
-      $this->paymentObject = $Przelewy24;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single Przelewy24 authorize
-   *
-   * @return string payment reference id for the Przelewy24 authorize transaction
-   * @group connectionTest
-   */
-  public function testAuthorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      
-      $this->paymentObject->authorize();
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+    /**
+     * Set up function will create a Przelewy24 object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $Przelewy24 = new Przelewy24();
+
+        $Przelewy24->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword,
+            $this->TransactionChannel, 'TRUE');
+
+        $Przelewy24->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId,
+            $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry,
+            $this->contactMail);
+
+
+        $Przelewy24->_dryRun = true;
+
+        $this->paymentObject = $Przelewy24;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * Test case for a single Przelewy24 authorize
+     *
+     * @return string payment reference id for the Przelewy24 authorize transaction
+     * @group connectionTest
+     */
+    public function testAuthorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+
+        $this->paymentObject->authorize();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 }

--- a/tests/Unit/PaymentMethods/SantanderInvoicePaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/SantanderInvoicePaymentMethodTest.php
@@ -6,11 +6,10 @@ use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\PaymentMethods\SantanderInvoicePaymentMethod as Invoice;
 
 /**
- *,
- *  Invoice B2C secured Test
+ * Invoice B2C secured Test
  *
- *  Connection tests can fail due to network issues and scheduled downtime.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtime.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -25,9 +24,7 @@ use Heidelpay\PhpApi\PaymentMethods\SantanderInvoicePaymentMethod as Invoice;
  */
 class SantanderInvoicePaymentMethodTest extends TestCase
 {
-
-    /** authentification parameter for heidelpay api
-     *
+    /**
      * @var array authentification parameter for heidelpay api
      */
     protected $authentification = array(
@@ -181,7 +178,6 @@ class SantanderInvoicePaymentMethodTest extends TestCase
     /**
      * Test case for a invoice reversal of a existing authorisation
      *
-
      *
      * @return string payment reference id for the prepayment reversal transaction
      * @depends Finalize

--- a/tests/Unit/PaymentMethods/SofortPaymentMethodTest.php
+++ b/tests/Unit/PaymentMethods/SofortPaymentMethodTest.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit\PaymentMethods;
 
 use PHPUnit\Framework\TestCase;
-use Heidelpay\PhpApi\PaymentMethods\SofortPaymentMethod as  Sofort;
+use Heidelpay\PhpApi\PaymentMethods\SofortPaymentMethod as Sofort;
 
 /**
+ * Sofort Test
  *
- *  Sofort Test
- *
- *  Connection tests can fail due to network issues and scheduled downtimes.
- *  This does not have to mean that your integration is broken. Please verify the given debug information
+ * Connection tests can fail due to network issues and scheduled downtimes.
+ * This does not have to mean that your integration is broken. Please verify the given debug information
  *
  * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
@@ -35,13 +35,13 @@ class SofortPaymentMerhodTest extends TestCase
      *
      * @var string UserLogin
      */
-    protected $UserLogin      = '31ha07bc8142c5a171744e5aef11ffd3';
+    protected $UserLogin = '31ha07bc8142c5a171744e5aef11ffd3';
     /**
      * UserPassword
      *
      * @var string UserPassword
      */
-    protected $UserPassword   = '93167DE7';
+    protected $UserPassword = '93167DE7';
     /**
      * TransactionChannel
      *
@@ -56,7 +56,7 @@ class SofortPaymentMerhodTest extends TestCase
      * @var string
      */
     protected $SandboxRequest = true;
-    
+
     /**
      * Customer given name
      *
@@ -68,7 +68,7 @@ class SofortPaymentMerhodTest extends TestCase
      *
      * @var string nameFamily
      */
-    protected $nameFamily ='Berger-Payment';
+    protected $nameFamily = 'Berger-Payment';
     /**
      * Customer company name
      *
@@ -92,19 +92,19 @@ class SofortPaymentMerhodTest extends TestCase
      *
      * @var string addressState
      */
-    protected $addressState  = 'DE-BW';
+    protected $addressState = 'DE-BW';
     /**
      * customer billing address zip
      *
      * @var string addressZip
      */
-    protected $addressZip    = '69115';
+    protected $addressZip = '69115';
     /**
      * customer billing address city
      *
      * @var string addressCity
      */
-    protected $addressCity    = 'Heidelberg';
+    protected $addressCity = 'Heidelberg';
     /**
      * customer billing address city
      *
@@ -117,7 +117,7 @@ class SofortPaymentMerhodTest extends TestCase
      * @var string contactMail
      */
     protected $contactMail = "development@heidelpay.de";
-    
+
     /**
      * Transaction currency
      *
@@ -135,7 +135,7 @@ class SofortPaymentMerhodTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * PaymentObject
      *
@@ -146,66 +146,69 @@ class SofortPaymentMerhodTest extends TestCase
     /**
      * Constructor used to set timezone to utc
      */
-  public function __construct()
-  {
-      date_default_timezone_set('UTC');
-  }
+    public function __construct()
+    {
+        date_default_timezone_set('UTC');
+    }
 
-  /**
-   * Set up function will create a sofort object for each testcase
-   *
-   * @see PHPUnit_Framework_TestCase::setUp()
-   */
-  public function setUp()
-  {
-      $Sofort = new Sofort();
-    
-      $Sofort->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword, $this->TransactionChannel, 'TRUE');
-    
-      $Sofort->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId, $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry, $this->contactMail);
-    
-    
-      $Sofort->_dryRun=true;
-    
-      $this->paymentObject = $Sofort;
-  }
-  
-  /**
-   * Get current called method, without namespace
-   *
-   * @param string $method
-   *
-   * @return string class and method
-   */
-  public function getMethod($method)
-  {
-      return substr(strrchr($method, '\\'), 1);
-  }
-    
-  /**
-   * Test case for a single sofort authorize
-   *
-   * @return string payment reference id for the sofort authorize transaction
-   * @group connectionTest
-   * @test
-   */
-  public function Authorize()
-  {
-      $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
-      $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
-      $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
-      
-      $this->paymentObject->authorize();
-      
-      /* prepare request and send it to payment api */
-      $request =  $this->paymentObject->getRequest()->convertToArray();
-      $response =  $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
-      
-      $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : '.print_r($response[1], 1));
-      $this->assertFalse($response[1]->isError(), 'authorize failed : '.print_r($response[1]->getError(), 1));
-      
-      return (string)$response[1]->getPaymentReferenceId();
-  }
+    /**
+     * Set up function will create a sofort object for each testcase
+     *
+     * @see PHPUnit_Framework_TestCase::setUp()
+     */
+    public function setUp()
+    {
+        $Sofort = new Sofort();
+
+        $Sofort->getRequest()->authentification($this->SecuritySender, $this->UserLogin, $this->UserPassword,
+            $this->TransactionChannel, 'TRUE');
+
+        $Sofort->getRequest()->customerAddress($this->nameGiven, $this->nameFamily, null, $this->shopperId,
+            $this->addressStreet, $this->addressState, $this->addressZip, $this->addressCity, $this->addressCountry,
+            $this->contactMail);
+
+
+        $Sofort->_dryRun = true;
+
+        $this->paymentObject = $Sofort;
+    }
+
+    /**
+     * Get current called method, without namespace
+     *
+     * @param string $method
+     *
+     * @return string class and method
+     */
+    public function getMethod($method)
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * Test case for a single sofort authorize
+     *
+     * @return string payment reference id for the sofort authorize transaction
+     * @group connectionTest
+     * @test
+     */
+    public function Authorize()
+    {
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
+        $this->paymentObject->getRequest()->basketData($timestamp, 23.12, $this->currency, $this->secret);
+        $this->paymentObject->getRequest()->async('DE', 'https://dev.heidelpay.de');
+
+        $this->paymentObject->authorize();
+
+        /* prepare request and send it to payment api */
+        $request = $this->paymentObject->getRequest()->convertToArray();
+        $response = $this->paymentObject->getRequest()->send($this->paymentObject->getPaymentUrl(), $request);
+
+        $this->assertTrue($response[1]->isSuccess(), 'Transaction failed : ' . print_r($response[1], 1));
+        $this->assertFalse($response[1]->isError(), 'authorize failed : ' . print_r($response[1]->getError(), 1));
+
+        return (string)$response[1]->getPaymentReferenceId();
+    }
 
     /**
      * Test case for Sofort refund
@@ -217,9 +220,9 @@ class SofortPaymentMerhodTest extends TestCase
      * @test
      * @group connectionTest
      */
-    public function Refund($referenceId=null)
+    public function Refund($referenceId = null)
     {
-        $timestamp = $this->getMethod(__METHOD__)." ".date("Y-m-d H:i:s");
+        $timestamp = $this->getMethod(__METHOD__) . " " . date("Y-m-d H:i:s");
         $this->paymentObject->getRequest()->basketData($timestamp, 3.54, $this->currency, $this->secret);
 
         /* the refund can not be processed because there will be no receipt automatically on the sandbox */

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit;
 
 use PHPUnit\Framework\TestCase;
@@ -24,161 +25,171 @@ use Heidelpay\PhpApi\ParameterGroups\CriterionParameterGroup;
 class RequestTest extends TestCase
 {
     /**
-    * Authentification test
-    *
-    * @desc This test will check if the authentification parameters are set.
-    * @group integrationTest
-    * @test
-    */
-  public function PrepareAuthentificationData()
-  {
-      $Request = new Request();
-      
-      $SecuritySender = '31HA07BC8142C5A171745D00AD63D182'; //SecuritySender
-      $UserLogin      = '31ha07bc8142c5a171744e5aef11ffd3'; // UserLogin
-      $UserPassword   = '93167DE7';                         // UserPassword
-      $TransactionChannel = '31HA07BC8142C5A171744F3D6D155865'; // TransactionChannel credit card without 3d scure
-      $SandboxRequest = true;
-      
-      $Request->authentification($SecuritySender, $UserLogin, $UserPassword, $TransactionChannel, $SandboxRequest);
-      
-      $this->assertEquals($SecuritySender, $Request->getSecurity()->getSender());
-      $this->assertEquals($UserLogin, $Request->getUser()->getLogin());
-      $this->assertEquals($UserPassword, $Request->getUser()->getPassword());
-      $this->assertEquals($TransactionChannel, $Request->getTransaction()->getChannel());
-      $this->assertEquals('CONNECTOR_TEST', $Request->getTransaction()->getMode());
-  }
-  
-  /**
-   * Set parameter for no synchron response
-   *
-   * @desc This test will check if the request can be set to async
-   * @group integrationTest
-   * @test
-   */
-  public function Async()
-  {
-      $Request = new Request();
-      
-      $LanguageCode = "DE";
-      $ResponseUrl  = "https://dev.heidelpay.de/";
-          
-      $Request->async($LanguageCode, $ResponseUrl);
-      
-      $this->assertEquals($LanguageCode, $Request->getFrontend()->getLanguage());
-      $this->assertEquals($ResponseUrl, $Request->getFrontend()->getResponseUrl());
-      $this->assertEquals('TRUE', $Request->getFrontend()->getEnabled());
-  }
-  
-  /**
-   * Customer address test
-   *
-   * @desc This test will check if all customer parameters can be added to the request object
-   * @group integrationTest
-   * @test
-   */
-  public function CustomerAddress()
-  {
-      $Request = new Request();
-      
-      $nameGiven = 'Heidel';
-      $nameFamily ='Berger-Payment';
-      $nameCompany = 'DevHeidelpay';
-      $shopperId = '12344';
-      $addressStreet = 'Vagerowstr. 18';
-      $addressState  = 'DE-BW';
-      $addressZip    = '69115';
-      $addressCity    = 'Heidelberg';
-      $addressCountry = 'DE';
-      $contactMail = "development@heidelpay.de";
-     
-     
-      $Request->customerAddress($nameGiven, $nameFamily, $nameCompany, $shopperId, $addressStreet, $addressState, $addressZip, $addressCity, $addressCountry, $contactMail);
-      
-      $this->assertEquals($nameGiven, $Request->getName()->getGiven());
-      $this->assertEquals($nameFamily, $Request->getName()->getFamily());
-      $this->assertEquals($nameCompany, $Request->getName()->getCompany());
-      $this->assertEquals($shopperId, $Request->getIdentification()->getShopperId());
-      $this->assertEquals($addressStreet, $Request->getAddress()->getStreet());
-      $this->assertEquals($addressState, $Request->getAddress()->getState());
-      $this->assertEquals($addressZip, $Request->getAddress()->getZip());
-      $this->assertEquals($addressCity, $Request->getAddress()->getCity());
-      $this->assertEquals($addressCountry, $Request->getAddress()->getCountry());
-  }
-  
-  /**
-   * Basket data test
-   *
-   * @desc This test will check if all customer parameters can be added to the request object
-   * @group integrationTest
-   * @test
-   */
-  public function SetBasketData()
-  {
-      $Request = new Request();
-      
-      $shopIdentifier = '2843294932';
-      $amount = 23.12;
-      $currency = 'EUR';
-      $secret = '39542395235ßfsokkspreipsr';
-      
-      $Request->basketData($shopIdentifier, $amount, $currency, $secret);
-      
-      $this->assertEquals($shopIdentifier, $Request->getIdentification()->getTransactionId());
-      $this->assertEquals($amount, $Request->getPresentation()->getAmount());
-      $this->assertEquals($currency, $Request->getPresentation()->getCurrency());
-      $this->assertEquals(hash('sha512', $shopIdentifier.$secret), $Request->getCriterion()->getSecretHash());
-  }
-  
-  /**
-   * Prepare request test
-   *
-   * @desc This test will convert the request object to post array format
-   * @group integrationTest
-   * @test
-   */
-  public function convertToArray()
-  {
-      $Request = new Request();
-      $Criterion = new CriterionParameterGroup();
-      
-      $shopIdentifier = '2843294932';
-      $amount = 23.12;
-      $currency = 'EUR';
-      $secret = '39542395235ßfsokkspreipsr';
-      
-      $Request->basketData($shopIdentifier, $amount, $currency, $secret);
-      
-      $referenceVars = array(
-        'CRITERION.SECRET'  => '209022666cd4706e5f451067592b6be1aff4a913d5bb7f8249f7418ee25c91b318ebac66f41a6692539c8923adfdad6aae26138b1b3a7e37a197ab952be57876',
-        'FRONTEND.ENABLED'  => 'TRUE',
-        'FRONTEND.MODE'     => 'WHITELABEL',
-        'IDENTIFICATION.TRANSACTIONID' => '2843294932',
-        'PRESENTATION.AMOUNT' => 23.12,
-        'PRESENTATION.CURRENCY' => 'EUR',
-        'REQUEST.VERSION' => '1.0',
-        'TRANSACTION.MODE' => 'CONNECTOR_TEST',
-        'CRITERION.SDK_NAME' => $Criterion->getSdkName(),
-        'CRITERION.SDK_VERSION' => $Criterion->getSdkVersion()
-       );
+     * Authentification test
+     *
+     * @desc This test will check if the authentification parameters are set.
+     * @group integrationTest
+     * @test
+     */
+    public function PrepareAuthentificationData()
+    {
+        $Request = new Request();
 
-      $this->assertEquals($referenceVars, $Request->convertToArray());
-  }
+        $SecuritySender = '31HA07BC8142C5A171745D00AD63D182'; //SecuritySender
+        $UserLogin = '31ha07bc8142c5a171744e5aef11ffd3'; // UserLogin
+        $UserPassword = '93167DE7';                         // UserPassword
+        $TransactionChannel = '31HA07BC8142C5A171744F3D6D155865'; // TransactionChannel credit card without 3d scure
+        $SandboxRequest = true;
+
+        $Request->authentification($SecuritySender, $UserLogin, $UserPassword, $TransactionChannel, $SandboxRequest);
+
+        $this->assertEquals($SecuritySender, $Request->getSecurity()->getSender());
+        $this->assertEquals($UserLogin, $Request->getUser()->getLogin());
+        $this->assertEquals($UserPassword, $Request->getUser()->getPassword());
+        $this->assertEquals($TransactionChannel, $Request->getTransaction()->getChannel());
+        $this->assertEquals('CONNECTOR_TEST', $Request->getTransaction()->getMode());
+    }
+
+    /**
+     * Set parameter for no synchron response
+     *
+     * @desc This test will check if the request can be set to async
+     * @group integrationTest
+     * @test
+     */
+    public function Async()
+    {
+        $Request = new Request();
+
+        $LanguageCode = "DE";
+        $ResponseUrl = "https://dev.heidelpay.de/";
+
+        $Request->async($LanguageCode, $ResponseUrl);
+
+        $this->assertEquals($LanguageCode, $Request->getFrontend()->getLanguage());
+        $this->assertEquals($ResponseUrl, $Request->getFrontend()->getResponseUrl());
+        $this->assertEquals('TRUE', $Request->getFrontend()->getEnabled());
+    }
+
+    /**
+     * Customer address test
+     *
+     * @desc This test will check if all customer parameters can be added to the request object
+     * @group integrationTest
+     * @test
+     */
+    public function CustomerAddress()
+    {
+        $Request = new Request();
+
+        $nameGiven = 'Heidel';
+        $nameFamily = 'Berger-Payment';
+        $nameCompany = 'DevHeidelpay';
+        $shopperId = '12344';
+        $addressStreet = 'Vagerowstr. 18';
+        $addressState = 'DE-BW';
+        $addressZip = '69115';
+        $addressCity = 'Heidelberg';
+        $addressCountry = 'DE';
+        $contactMail = "development@heidelpay.de";
+
+        $Request->customerAddress(
+            $nameGiven,
+            $nameFamily,
+            $nameCompany,
+            $shopperId,
+            $addressStreet,
+            $addressState,
+            $addressZip,
+            $addressCity,
+            $addressCountry,
+            $contactMail
+        );
+
+        $this->assertEquals($nameGiven, $Request->getName()->getGiven());
+        $this->assertEquals($nameFamily, $Request->getName()->getFamily());
+        $this->assertEquals($nameCompany, $Request->getName()->getCompany());
+        $this->assertEquals($shopperId, $Request->getIdentification()->getShopperId());
+        $this->assertEquals($addressStreet, $Request->getAddress()->getStreet());
+        $this->assertEquals($addressState, $Request->getAddress()->getState());
+        $this->assertEquals($addressZip, $Request->getAddress()->getZip());
+        $this->assertEquals($addressCity, $Request->getAddress()->getCity());
+        $this->assertEquals($addressCountry, $Request->getAddress()->getCountry());
+    }
+
+    /**
+     * Basket data test
+     *
+     * @desc This test will check if all customer parameters can be added to the request object
+     * @group integrationTest
+     * @test
+     */
+    public function SetBasketData()
+    {
+        $Request = new Request();
+
+        $shopIdentifier = '2843294932';
+        $amount = 23.12;
+        $currency = 'EUR';
+        $secret = '39542395235ßfsokkspreipsr';
+
+        $Request->basketData($shopIdentifier, $amount, $currency, $secret);
+
+        $this->assertEquals($shopIdentifier, $Request->getIdentification()->getTransactionId());
+        $this->assertEquals($amount, $Request->getPresentation()->getAmount());
+        $this->assertEquals($currency, $Request->getPresentation()->getCurrency());
+        $this->assertEquals(hash('sha512', $shopIdentifier . $secret), $Request->getCriterion()->getSecretHash());
+    }
+
+    /**
+     * Prepare request test
+     *
+     * @desc This test will convert the request object to post array format
+     * @group integrationTest
+     * @test
+     */
+    public function convertToArray()
+    {
+        $Request = new Request();
+        $Criterion = new CriterionParameterGroup();
+
+        $shopIdentifier = '2843294932';
+        $amount = 23.12;
+        $currency = 'EUR';
+        $secret = '39542395235ßfsokkspreipsr';
+
+        $Request->basketData($shopIdentifier, $amount, $currency, $secret);
+
+        $referenceVars = array(
+            'CRITERION.SECRET' => '209022666cd4706e5f451067592b6be1aff4a913d5bb7f8249f7418ee25c91b318ebac66f41a6692539c8923adfdad6aae26138b1b3a7e37a197ab952be57876',
+            'FRONTEND.ENABLED' => 'TRUE',
+            'FRONTEND.MODE' => 'WHITELABEL',
+            'IDENTIFICATION.TRANSACTIONID' => '2843294932',
+            'PRESENTATION.AMOUNT' => 23.12,
+            'PRESENTATION.CURRENCY' => 'EUR',
+            'REQUEST.VERSION' => '1.0',
+            'TRANSACTION.MODE' => 'CONNECTOR_TEST',
+            'CRITERION.SDK_NAME' => $Criterion->getSdkName(),
+            'CRITERION.SDK_VERSION' => $Criterion->getSdkVersion()
+        );
+
+        $this->assertEquals($referenceVars, $Request->convertToArray());
+    }
 
     /**
      * Basket parameter group getter test
      *
      * @test
      */
-  public function getBasket()
-  {
-      $Request = new Request();
+    public function getBasket()
+    {
+        $Request = new Request();
 
-      $Request->getBasket();
-      $value = "31HA07BC8129FBB819367B2205CD6FB4";
-      $Request->getBasket()->set('id', $value);
-      $this->assertEquals($value, $Request->getBasket()->getId());
-  }
+        $Request->getBasket();
+        $value = "31HA07BC8129FBB819367B2205CD6FB4";
+        $Request->getBasket()->set('id', $value);
+        $this->assertEquals($value, $Request->getBasket()->getId());
+    }
 
     /**
      * Request parameter group getter test

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -1,8 +1,11 @@
 <?php
+
 namespace Heidelpay\Tests\PhpApi\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Heidelpay\PhpApi\Response;
+use Heidelpay\PhpApi\Exceptions\PaymentFormUrlException;
+use Heidelpay\PhpApi\Exceptions\HashVerificationException;
 
 /**
  *
@@ -19,9 +22,6 @@ use Heidelpay\PhpApi\Response;
  * @subpackage PhpApi
  * @category UnitTest
  */
-use Heidelpay\PhpApi\Exceptions\PaymentFormUrlException;
-use Heidelpay\PhpApi\Exceptions\HashVerificationException;
-
 class ResponseTest extends TestCase
 {
     /**
@@ -40,7 +40,7 @@ class ResponseTest extends TestCase
      * @var string secret
      */
     protected $secret = 'Heidelpay-PhpApi';
-    
+
     /**
      * setUp sample response Object
      *
@@ -96,108 +96,105 @@ class ResponseTest extends TestCase
             'FRONTEND_LANGUAGE' => 'DE',
             'PAYMENT_CODE' => 'CC.RG',
             'BASKET_ID' => '31HA07BC8129FBB819367B2205CD6FB4'
-            );
-        
+        );
+
         $this->_resposneObject = new Response($responseSample);
     }
-    
-   /**
-    * function test for isSuccess method
-    *
-    * @group integrationTest
-    * @test
-    */
-  public function IsSuccess()
-  {
-      $this->assertTrue($this->_resposneObject->isSuccess(), 'isSuccess should be true');
-      $this->_resposneObject->getProcessing()->set('result', 'NOK');
-      $this->assertFalse($this->_resposneObject->isSuccess(), 'isSuccess should be false.');
-  }
-  
-  /**
-   * function test for isPending method
-   *
-   * @group integrationTest
-   * @test
-   */
-  public function IsPending()
-  {
-      $this->assertFalse($this->_resposneObject->isPending(), 'isPending should be false');
-      $this->_resposneObject->getProcessing()->set('status_code', '80');
-      $this->assertTrue($this->_resposneObject->isPending(), 'isPending should be true');
-  }
-  
-  /**
-   * function test for isError method
-   *
-   * @group integrationTest
-   * @test
-   */
-  public function IsError()
-  {
-      $this->assertFalse($this->_resposneObject->isError(), 'isError should be false');
-      $this->_resposneObject->getProcessing()->set('result', 'NOK');
-      $this->assertTrue($this->_resposneObject->isError(), 'isError should be true');
-  }
-  
-  /**
-   * function test for getError method
-   *
-   * @group integrationTest
-   * @test
-   */
-  public function GetError()
-  {
-      $expectedError = array(
+
+    /**
+     * function test for isSuccess method
+     *
+     * @group integrationTest
+     * @test
+     */
+    public function IsSuccess()
+    {
+        $this->assertTrue($this->_resposneObject->isSuccess(), 'isSuccess should be true');
+        $this->_resposneObject->getProcessing()->set('result', 'NOK');
+        $this->assertFalse($this->_resposneObject->isSuccess(), 'isSuccess should be false.');
+    }
+
+    /**
+     * function test for isPending method
+     *
+     * @group integrationTest
+     * @test
+     */
+    public function IsPending()
+    {
+        $this->assertFalse($this->_resposneObject->isPending(), 'isPending should be false');
+        $this->_resposneObject->getProcessing()->set('status_code', '80');
+        $this->assertTrue($this->_resposneObject->isPending(), 'isPending should be true');
+    }
+
+    /**
+     * function test for isError method
+     *
+     * @group integrationTest
+     * @test
+     */
+    public function IsError()
+    {
+        $this->assertFalse($this->_resposneObject->isError(), 'isError should be false');
+        $this->_resposneObject->getProcessing()->set('result', 'NOK');
+        $this->assertTrue($this->_resposneObject->isError(), 'isError should be true');
+    }
+
+    /**
+     * function test for getError method
+     *
+     * @group integrationTest
+     * @test
+     */
+    public function GetError()
+    {
+        $expectedError = array(
             'code' => '000.100.112',
             'message' => "Request successfully processed in 'Merchant in Connector Test Mode'"
-       );
-  
-      $this->assertEquals($expectedError, $this->_resposneObject->getError());
-  }
-  
-  /**
-   * function test for getPaymentReferenceID method
-   *
-   * @group integrationTest
-   * @test
-   */
-  public function GetPaymentReferenceId()
-  {
-      $this->assertEquals('31HA07BC8108A9126F199F2784552637', $this->_resposneObject->getPaymentReferenceId());
-  }
-  
-  /**
-   * function test for getPaymentFormUrl method
-   *
-   * @group integrationTest
-   * @test
-   */
-  public function GetPaymentFormUrl()
-  {
-           
-      /** iframe url for credit and debit card*/
-      $expectedUrl = 'http://dev.heidelpay.de';
-      $this->_resposneObject->getFrontend()->set('payment_frame_url', $expectedUrl);
-      $this->assertEquals($expectedUrl, $this->_resposneObject->getPaymentFormUrl());
-      
-      
-      $expectedUrl = 'http://www.heidelpay.de';
-      $this->_resposneObject->getFrontend()->set('redirect_url', $expectedUrl);
-      
-      /** url in case of credit and debit card refernce Transaction */
-      $this->_resposneObject->getIdentification()->set('referenceid', '31HA07BC8108A9126F199F2784552637');
-      $this->assertEquals($expectedUrl, $this->_resposneObject->getPaymentFormUrl());
-      
-      /** unset reference id */
-      $this->_resposneObject->getIdentification()->set('referenceid', null);
-       
-      
-      /** url for non credit or debit card transactions */
-      $this->_resposneObject->getPayment()->set('code', 'OT.PA');
-      $this->_resposneObject->getFrontend()->set('redirect_url', $expectedUrl);
-      $this->assertEquals($expectedUrl, $this->_resposneObject->getPaymentFormUrl());
-  }
+        );
+
+        $this->assertEquals($expectedError, $this->_resposneObject->getError());
+    }
+
+    /**
+     * function test for getPaymentReferenceID method
+     *
+     * @group integrationTest
+     * @test
+     */
+    public function GetPaymentReferenceId()
+    {
+        $this->assertEquals('31HA07BC8108A9126F199F2784552637', $this->_resposneObject->getPaymentReferenceId());
+    }
+
+    /**
+     * function test for getPaymentFormUrl method
+     *
+     * @group integrationTest
+     * @test
+     */
+    public function GetPaymentFormUrl()
+    {
+        /** iframe url for credit and debit card*/
+        $expectedUrl = 'http://dev.heidelpay.de';
+        $this->_resposneObject->getFrontend()->set('payment_frame_url', $expectedUrl);
+        $this->assertEquals($expectedUrl, $this->_resposneObject->getPaymentFormUrl());
+
+        $expectedUrl = 'http://www.heidelpay.de';
+        $this->_resposneObject->getFrontend()->set('redirect_url', $expectedUrl);
+
+        /** url in case of credit and debit card refernce Transaction */
+        $this->_resposneObject->getIdentification()->set('referenceid', '31HA07BC8108A9126F199F2784552637');
+        $this->assertEquals($expectedUrl, $this->_resposneObject->getPaymentFormUrl());
+
+        /** unset reference id */
+        $this->_resposneObject->getIdentification()->set('referenceid', null);
+
+        /** url for non credit or debit card transactions */
+        $this->_resposneObject->getPayment()->set('code', 'OT.PA');
+        $this->_resposneObject->getFrontend()->set('redirect_url', $expectedUrl);
+        $this->assertEquals($expectedUrl, $this->_resposneObject->getPaymentFormUrl());
+    }
 
     /**
      * PaymentFormUrlPaymentCodeException test
@@ -220,28 +217,28 @@ class ResponseTest extends TestCase
      * @group integrationTest
      * @test
      */
-  public function getPaymentFormUrlException()
-  {
-      $Response = new Response();
+    public function getPaymentFormUrlException()
+    {
+        $Response = new Response();
 
-      $Response->getPayment()->set('code', 'OT.PA');
-      $Response->getFrontend()->set('redirect_url', null);
-      $this->expectException(PaymentFormUrlException::class);
-      $Response->getPaymentFormUrl();
-  }
-  
-  /**
-   * function test for verifySecurityHashUndefiledParameter
-   *
-   * @group integrationTest
-   * @test
-   */
-  public function verifySecurityHashUndefiledParameter()
-  {
-      $Response = new Response();
-      $this->expectException(HashVerificationException::class);
-      $Response->verifySecurityHash(null, null);
-  }
+        $Response->getPayment()->set('code', 'OT.PA');
+        $Response->getFrontend()->set('redirect_url', null);
+        $this->expectException(PaymentFormUrlException::class);
+        $Response->getPaymentFormUrl();
+    }
+
+    /**
+     * function test for verifySecurityHashUndefiledParameter
+     *
+     * @group integrationTest
+     * @test
+     */
+    public function verifySecurityHashUndefiledParameter()
+    {
+        $Response = new Response();
+        $this->expectException(HashVerificationException::class);
+        $Response->verifySecurityHash(null, null);
+    }
 
     /**
      * function test for verifySecurityHashEmptyResponse
@@ -280,11 +277,17 @@ class ResponseTest extends TestCase
     {
         $Response = new Response();
         $Response->getProcessing()->set('result', 'ACK');
-        $Response->getCriterion()->set('secret',
+        $Response->getCriterion()->set(
+            'secret',
             '84c48ba8b3386a4e2f38ef5eeb3b3544788f675eef63c6e83c828049b706aa7e57ba69243902bfcd105'
-            .'c1ed28b6519fb4277b3355b9807819dd4b0414722a3f5');
-        $this->assertTrue($Response->verifySecurityHash($this->secret,
-            'InvoicePaymentMethodTest::Refund 2017-02-24 10:22:35'));
+            . 'c1ed28b6519fb4277b3355b9807819dd4b0414722a3f5'
+        );
+        $this->assertTrue(
+            $Response->verifySecurityHash(
+                $this->secret,
+                'InvoicePaymentMethodTest::Refund 2017-02-24 10:22:35'
+            )
+        );
     }
 
     /**
@@ -298,10 +301,11 @@ class ResponseTest extends TestCase
         $Response = new Response();
         $Response->getProcessing()->set('result', 'ACK');
         $this->expectException(HashVerificationException::class);
-        $Response->getCriterion()->set('secret',
+        $Response->getCriterion()->set(
+            'secret',
             '84c48ba8b3386a4e2f38ef5eeb3b3544788f675eef63c6e83c828049b706aa7e57ba69243902bfcd105'
-            .'c1ed28b6519fb4277b3355b9807819dd4b0414722a3f5');
-        $Response->verifySecurityHash($this->secret,
-            'false');
+            . 'c1ed28b6519fb4277b3355b9807819dd4b0414722a3f5'
+        );
+        $Response->verifySecurityHash($this->secret, 'false');
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,6 @@
 <?php
 
-require_once  __DIR__ . '/../vendor/autoload.php';
-
+require_once __DIR__ . '/../vendor/autoload.php';
 
 // Fix broken OpenSSL lib on Travis CI
 if (getenv('TRAVIS')) {


### PR DESCRIPTION
## XML Push Mapper [Beta]
This PR marks the beta release of the XML Push Mapper, which is used for heidelpay Push notifications, e.g. for receipts in invoice payments, prepayment, etc.

Heidelpay PHP SDK functionality is not being changed here, it just adds the XML Push mapping functionality.

This is beta, because unit tests are missing right now.